### PR TITLE
refactor(plugins): split skills into independent plugins with user_invocable flag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,31 @@
     {
       "name": "java-coder",
       "source": "./plugins/java-coder",
-      "description": "Production-grade Java patterns — Java 25, Spring Boot 4, DDD, TDD, and stability patterns",
+      "description": "Production-grade Java patterns — SOLID, Clean Code, DDD, Effective Java, and stability patterns",
+      "version": "0.0.1"
+    },
+    {
+      "name": "java-reviewer",
+      "source": "./plugins/java-reviewer",
+      "description": "Java code review checklists — Code Quality, DDD/Architecture, Effective Java, Stability/Production Readiness, and Spring Boot/API",
+      "version": "0.0.1"
+    },
+    {
+      "name": "java-tester",
+      "source": "./plugins/java-tester",
+      "description": "Java TDD workflow and test writing — Red-Green-Refactor, test type strategy, Mockito, Testcontainers, legacy code testing",
+      "version": "0.0.1"
+    },
+    {
+      "name": "java-25",
+      "source": "./plugins/java-25",
+      "description": "Java 25 LTS feature guide — records, sealed classes, pattern matching, virtual threads, ScopedValue, structured concurrency, stable values",
+      "version": "0.0.1"
+    },
+    {
+      "name": "spring",
+      "source": "./plugins/spring",
+      "description": "Spring Boot 4 conventions — constructor injection, ProblemDetail, REST patterns, test annotations, security, observability, migration",
       "version": "0.0.1"
     }
   ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,9 @@
 {
   "enabledPlugins": {
-    "java-coder@java-plugins": true
+    "java-coder@java-plugins": true,
+    "java-reviewer@java-plugins": true,
+    "java-tester@java-plugins": true,
+    "java-25@java-plugins": true,
+    "spring@java-plugins": true
   }
 }

--- a/plugins/java-25/.claude-plugin/plugin.json
+++ b/plugins/java-25/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "java-25",
+  "version": "0.0.1",
+  "description": "Java 25 LTS feature guide — records, sealed classes, pattern matching, virtual threads, ScopedValue, structured concurrency, stable values",
+  "author": {
+    "name": "ppzxc",
+    "email": "cjh8487@naver.com",
+    "url": "https://ppzxc.github.io"
+  }
+}

--- a/plugins/java-25/README.ko.md
+++ b/plugins/java-25/README.ko.md
@@ -1,0 +1,28 @@
+# java-25
+
+Java 25 LTS 기능 가이드 스킬입니다.
+
+## 포함 내용
+
+1. **기능 빠른 참조** — var, records, sealed classes, pattern matching, virtual threads, ScopedValue, text blocks, SequencedCollection, structured concurrency, stable values
+2. **Virtual Thread 안전성** — `synchronized` → `ReentrantLock`, `ThreadLocal` → `ScopedValue` (필수 규칙)
+3. **Records** — DTO, Value Object, 불변 데이터 캐리어
+4. **Sealed Classes** — 완전한 패턴 매칭 switch와 함께 사용하는 대수 타입
+5. **ScopedValue** — Virtual Thread 환경에서 ThreadLocal 대체
+
+## 설치
+
+```bash
+/plugin marketplace add ppzxc/java-plugins
+/plugin install java-25
+```
+
+## 사용 방법
+
+설치 후 Claude Code에서 슬래시 커맨드로 스킬을 호출합니다:
+
+```
+/java-25
+```
+
+records, sealed classes, virtual threads, ScopedValue 등 Java 25 기능을 사용하거나 Virtual Thread 안전성 확인 시 자동으로 활성화됩니다.

--- a/plugins/java-25/README.md
+++ b/plugins/java-25/README.md
@@ -1,0 +1,28 @@
+# java-25
+
+A Java 25 LTS feature guide skill for Claude Code.
+
+## Contents
+
+1. **Feature Quick Reference** — var, records, sealed classes, pattern matching, virtual threads, ScopedValue, text blocks, SequencedCollection, structured concurrency, stable values
+2. **Virtual Thread Safety** — `synchronized` → `ReentrantLock`, `ThreadLocal` → `ScopedValue` (non-negotiable rules)
+3. **Records** — DTOs, Value Objects, immutable data carriers
+4. **Sealed Classes** — Algebraic types with exhaustive pattern matching switch
+5. **ScopedValue** — Replacing ThreadLocal in Virtual Thread environments
+
+## Installation
+
+```bash
+/plugin marketplace add ppzxc/java-plugins
+/plugin install java-25
+```
+
+## Usage
+
+Invoke as a slash command in Claude Code:
+
+```
+/java-25
+```
+
+Also activates automatically when writing or reviewing Java code that uses Java 25 features — records, sealed classes, virtual threads, ScopedValue, or checking Virtual Thread safety.

--- a/plugins/java-25/skills/java-25/SKILL.md
+++ b/plugins/java-25/skills/java-25/SKILL.md
@@ -5,6 +5,7 @@ description: >
   pattern matching (instanceof/switch), virtual threads, ScopedValue, structured concurrency,
   stable values, or other Java 25+ language and API features.
   Also use when checking Virtual Thread safety (synchronized blocks, ThreadLocal usage).
+user_invocable: true
 ---
 
 # Java 25
@@ -26,7 +27,7 @@ Java 25 (LTS, September 2025) feature guide with usage conventions and best prac
 | Structured Concurrency | Coordinate multiple concurrent tasks as a single logical unit |
 | Stable Values | Lazy initialization replacing double-checked locking |
 
-Full reference → `../java-coder/references/java25-features.md`
+Full reference → `references/java25-features.md`
 
 ---
 
@@ -114,4 +115,4 @@ ScopedValue.runWhere(RequestContext.currentUser(), authenticatedUserId, () -> {
 
 | File | When to Open |
 |------|-------------|
-| `../java-coder/references/java25-features.md` | Complete Java 25 reference — all features with examples |
+| `references/java25-features.md` | Complete Java 25 reference — all features with examples |

--- a/plugins/java-25/skills/java-25/references/java25-features.md
+++ b/plugins/java-25/skills/java-25/references/java25-features.md
@@ -1,0 +1,346 @@
+# Java 25 Feature Usage Guide
+
+This document covers Java 25 (LTS, released September 2025) features that have the most impact on everyday coding.
+
+## Table of Contents
+1. [Records and Pattern Matching](#records-and-pattern-matching)
+2. [Sealed Classes / Interfaces](#sealed-classes--interfaces)
+3. [Switch Expressions & Pattern Matching](#switch-expressions--pattern-matching)
+4. [Primitive Types in Patterns](#primitive-types-in-patterns)
+5. [Flexible Constructor Bodies](#flexible-constructor-bodies)
+6. [Scoped Values](#scoped-values)
+7. [Structured Concurrency](#structured-concurrency)
+8. [Stable Values](#stable-values)
+9. [Module Import Declarations](#module-import-declarations)
+10. [Compact Source Files & Instance Main Methods](#compact-source-files)
+11. [Text Blocks](#text-blocks)
+12. [Virtual Threads](#virtual-threads)
+13. [Other Useful Features](#other-useful-features)
+
+---
+
+## Records and Pattern Matching
+
+Use records for immutable data carriers. They are ideal for DTOs, value objects, and events.
+
+**Do use:**
+```java
+// DTO
+public record CreateOrderRequest(
+    String itemCode,
+    int quantity,
+    @Nullable String couponCode
+) {
+  // Compact constructor for validation
+  public CreateOrderRequest {
+    if (quantity <= 0) {
+      throw new IllegalArgumentException("Quantity must be positive: " + quantity);
+    }
+  }
+}
+
+// Value object
+public record Money(BigDecimal amount, Currency currency) {
+  public Money add(Money other) {
+    if (!this.currency.equals(other.currency)) {
+      throw new IllegalArgumentException("Currency mismatch");
+    }
+    return new Money(this.amount.add(other.amount), this.currency);
+  }
+}
+```
+
+**Record pattern deconstruction:**
+```java
+if (shape instanceof Rectangle(Point(var x1, var y1), Point(var x2, var y2))) {
+  double width = Math.abs(x2 - x1);
+  double height = Math.abs(y2 - y1);
+}
+```
+
+**Do NOT use records for:**
+- JPA Entities (require default constructor and mutable fields)
+- Types that need inheritance
+- Complex domain objects with extensive business logic
+
+---
+
+## Sealed Classes / Interfaces
+
+Explicitly restrict the set of permitted subtypes for a domain type. When combined with pattern matching switch, the compiler enforces exhaustiveness.
+
+```java
+public sealed interface PaymentMethod
+    permits CreditCard, BankTransfer, DigitalWallet {
+}
+
+public record CreditCard(String cardNumber, YearMonth expiry) implements PaymentMethod {}
+public record BankTransfer(String bankCode, String accountNumber) implements PaymentMethod {}
+public record DigitalWallet(String walletId, WalletProvider provider) implements PaymentMethod {}
+
+// Exhaustive switch — no default needed
+public BigDecimal calculateFee(PaymentMethod method) {
+  return switch (method) {
+    case CreditCard cc -> cc.expiry().isBefore(YearMonth.now())
+        ? BigDecimal.ZERO
+        : new BigDecimal("0.03");
+    case BankTransfer _ -> new BigDecimal("0.01");
+    case DigitalWallet dw -> switch (dw.provider()) {
+      case KAKAO_PAY -> BigDecimal.ZERO;
+      default -> new BigDecimal("0.02");
+    };
+  };
+}
+```
+
+---
+
+## Switch Expressions & Pattern Matching
+
+Use switch expressions for value-returning branches. They are more readable than if-else chains.
+
+```java
+// Basic switch expression
+String label = switch (status) {
+  case PENDING -> "Pending";
+  case APPROVED -> "Approved";
+  case REJECTED -> "Rejected";
+};
+
+// Pattern matching with guards (when clause)
+String describe(Object obj) {
+  return switch (obj) {
+    case Integer i when i > 0 -> "Positive integer: " + i;
+    case Integer i -> "Integer: " + i;
+    case String s when s.isBlank() -> "Blank string";
+    case String s -> "String: " + s;
+    case null -> "null";
+    default -> "Other: " + obj;
+  };
+}
+```
+
+**Conventions:**
+- Default to `->` (arrow) syntax in switch expressions
+- Use `:` (colon) syntax only when fall-through is needed (should be extremely rare)
+- Use `_` (unnamed variable) for unused bindings
+
+---
+
+## Primitive Types in Patterns
+
+Java 25 allows primitive type patterns in instanceof and switch (Preview).
+
+```java
+// Primitive pattern in instanceof
+static void process(Object obj) {
+  if (obj instanceof int i) {
+    System.out.println("Integer: " + i);
+  }
+}
+
+// Primitive type in switch
+static String classify(int value) {
+  return switch (value) {
+    case 0 -> "zero";
+    case int i when i > 0 -> "positive";
+    case int i -> "negative";
+  };
+}
+```
+
+> This feature is in Preview in Java 25. Use in production only after team consensus.
+
+---
+
+## Flexible Constructor Bodies
+
+Java 25 allows validation, logging, and transformations before super() or this() calls.
+
+```java
+public class PremiumOrder extends Order {
+
+  public PremiumOrder(String itemCode, int quantity, String membershipId) {
+    // Validation before super() — Java 25
+    if (membershipId == null || membershipId.isBlank()) {
+      throw new IllegalArgumentException("Premium orders require a membership ID");
+    }
+    var normalizedId = membershipId.strip().toUpperCase();
+    super(itemCode, quantity);
+    this.membershipId = normalizedId;
+  }
+}
+```
+
+---
+
+## Scoped Values
+
+Use ScopedValue instead of ThreadLocal in Virtual Thread environments. Scoped values are immutable and automatically cleaned up when the scope ends.
+
+```java
+public class RequestContext {
+
+  private static final ScopedValue<String> CURRENT_USER = ScopedValue.newInstance();
+
+  public static ScopedValue<String> currentUser() {
+    return CURRENT_USER;
+  }
+}
+
+// Usage
+ScopedValue.runWhere(RequestContext.currentUser(), authenticatedUserId, () -> {
+  orderService.createOrder(request);
+  // Downstream methods access via RequestContext.currentUser().get()
+});
+```
+
+**Conventions:**
+- Declare ScopedValue instances as `private static final` with accessor methods
+- Use `ScopedValue.callWhere` for nested bindings that return values
+- Particularly useful in thread-per-request + Virtual Thread environments
+
+---
+
+## Structured Concurrency
+
+Coordinate multiple concurrent tasks as a single logical unit. If one subtask fails, the rest are automatically cancelled.
+
+```java
+OrderSummary fetchOrderSummary(long orderId) throws Exception {
+  try (var scope = StructuredTaskScope.open()) {
+    var orderTask = scope.fork(() -> orderRepository.findById(orderId));
+    var paymentTask = scope.fork(() -> paymentClient.getPaymentStatus(orderId));
+    var deliveryTask = scope.fork(() -> deliveryClient.getTrackingInfo(orderId));
+
+    scope.join();
+
+    return new OrderSummary(
+        orderTask.get(),
+        paymentTask.get(),
+        deliveryTask.get()
+    );
+  }
+}
+```
+
+---
+
+## Stable Values
+
+Use for lazily initialized immutable values. The JVM optimizes them like final fields.
+
+```java
+@Service
+public class NotificationService {
+
+  // Initialized once on first access
+  private final StableValue<EmailClient> emailClient = StableValue.of();
+
+  private EmailClient getEmailClient() {
+    return emailClient.orElseSet(() -> EmailClient.create(emailConfig));
+  }
+}
+```
+
+**Conventions:**
+- Use when initialization is expensive and should be deferred
+- Replace double-checked locking patterns with StableValue
+- Preview in Java 25 — use after team consensus
+
+---
+
+## Module Import Declarations
+
+`import module` imports all exported packages from a module at once.
+
+```java
+import module java.base; // imports java.util, java.io, java.time, etc.
+import module java.sql;
+```
+
+**Conventions:**
+- Using `import module java.base` significantly reduces boilerplate
+- Standardize usage across the project (no mixing with individual imports for the same module)
+- Keep individual imports when you want explicit visibility of which package a class comes from
+
+---
+
+## Compact Source Files
+
+Single-class programs can omit `public`, `static`, and `String[] args`. Suitable for prototypes and scripts, but **keep the traditional format for production Spring Boot projects**.
+
+```java
+// Compact entry point (learning / prototypes only)
+void main() {
+  System.out.println("Hello, Java 25!");
+}
+```
+
+---
+
+## Text Blocks
+
+Use text blocks for multi-line strings.
+
+```java
+String query = """
+    SELECT o.id, o.status, o.total_amount
+    FROM orders o
+    WHERE o.created_at >= :startDate
+      AND o.status = :status
+    ORDER BY o.created_at DESC
+    """;
+
+String json = """
+    {
+      "orderId": "%s",
+      "status": "CREATED"
+    }
+    """.formatted(orderId);
+```
+
+---
+
+## Virtual Threads
+
+In Spring Boot 4, enable with `spring.threads.virtual.enabled=true`.
+
+**Conventions:**
+- Default to Virtual Threads for I/O-bound workloads
+- Use `ReentrantLock` instead of `synchronized` blocks (prevents Virtual Thread pinning)
+- Use ScopedValue instead of ThreadLocal
+- Keep platform thread pools for CPU-bound work
+
+---
+
+## Other Useful Features
+
+### Unnamed Variables (`_`)
+Use `_` for unused variables:
+```java
+try {
+  processOrder(order);
+} catch (OrderNotFoundException _) {
+  return defaultOrder();
+}
+
+orders.stream()
+    .map((var _) -> generateSequenceNumber())
+    .toList();
+```
+
+### Sequenced Collections
+Use `getFirst()`, `getLast()`, `reversed()` on ordered collections:
+```java
+var firstOrder = orders.getFirst();
+var lastOrder = orders.getLast();
+var reversed = orders.reversed();
+```
+
+### Key Derivation Function API
+Use the standard API for password-based key derivation (no third-party libraries needed):
+```java
+KDF hkdf = KDF.getInstance("HKDF-SHA256");
+SecretKey key = hkdf.deriveKey("AES", params);
+```

--- a/plugins/java-coder/README.ko.md
+++ b/plugins/java-coder/README.ko.md
@@ -1,34 +1,29 @@
 # java-coder
 
-Production-grade Java 패턴 플러그인입니다. 5개의 집중화된 스킬을 포함합니다.
+Production-grade Java 패턴 스킬입니다.
 
 11권의 책 기반: Clean Code, SOLID, Pragmatic Programmer, Code Complete, Refactoring, Design Patterns, TDD, Legacy Code, Effective Java, DDD, Release It!
 
-## 스킬 구성
+## 포함 내용
 
-| 스킬 | 트리거 |
-|------|--------|
-| **java-coder** | Java 코드 작성, 설계, 리팩토링 |
-| **java-25** | Java 25 기능 — records, sealed classes, virtual threads, ScopedValue |
-| **spring** | Spring Boot 4 — 컨벤션, REST 패턴, 테스트 어노테이션, ProblemDetail |
-| **java-tester** | TDD 워크플로우, 테스트 작성 (*Test.java, *IT.java) |
-| **java-reviewer** | 코드 리뷰, 품질 감사, 아키텍처 준수 |
+1. **설계 원칙** — SOLID, Clean Code, Effective Java 관용구
+2. **DDD 패턴** — Aggregate, Value Object, Domain Event, Context Mapping, 모듈 매핑
+3. **안정성 패턴** — Circuit Breaker, Bulkhead, Timeout, Retry, 안티패턴
+4. **포매팅 컨벤션** — 네이밍, 함수 크기, 구조 규칙
 
 ## 설치
 
 ```bash
 /plugin marketplace add ppzxc/java-plugins
-/plugin install java-plugins
+/plugin install java-coder
 ```
 
 ## 사용 방법
 
-각 스킬은 컨텍스트에 따라 자동으로 활성화됩니다:
+설치 후 Claude Code에서 슬래시 커맨드로 스킬을 호출합니다:
 
 ```
-/java-coder     # 코드 작성 및 설계
-/java-25        # Java 25 기능 레퍼런스
-/spring         # Spring Boot 4 컨벤션
-/java-tester    # TDD 및 테스트
-/java-reviewer  # 코드 리뷰
+/java-coder
 ```
+
+Java 코드 작성, 설계, 리팩토링 시 자동으로 활성화됩니다.

--- a/plugins/java-coder/README.md
+++ b/plugins/java-coder/README.md
@@ -1,34 +1,29 @@
 # java-coder
 
-A production-grade Java patterns plugin for Claude Code containing 5 focused skills.
+A production-grade Java patterns skill for Claude Code.
 
 Based on eleven canonical books: Clean Code, SOLID, Pragmatic Programmer, Code Complete, Refactoring, Design Patterns, TDD, Legacy Code, Effective Java, DDD, Release It!
 
-## Skills
+## Contents
 
-| Skill | Trigger |
-|-------|---------|
-| **java-coder** | Writing, designing, or refactoring Java code |
-| **java-25** | Java 25 features — records, sealed classes, virtual threads, ScopedValue |
-| **spring** | Spring Boot 4 — conventions, REST patterns, test annotations, ProblemDetail |
-| **java-tester** | TDD workflow, writing tests (*Test.java, *IT.java) |
-| **java-reviewer** | Code review, quality audits, architecture compliance |
+1. **Design Principles** — SOLID, Clean Code, Effective Java idioms
+2. **DDD Patterns** — Aggregate, Value Object, Domain Event, Context Mapping, module mapping
+3. **Stability Patterns** — Circuit Breaker, Bulkhead, Timeout, Retry, anti-patterns
+4. **Formatting Conventions** — Naming, function size, structure rules
 
 ## Installation
 
 ```bash
 /plugin marketplace add ppzxc/java-plugins
-/plugin install java-plugins
+/plugin install java-coder
 ```
 
 ## Usage
 
-Each skill activates automatically based on context:
+Invoke as a slash command in Claude Code:
 
 ```
-/java-coder     # Code writing and design
-/java-25        # Java 25 feature reference
-/spring         # Spring Boot 4 conventions
-/java-tester    # TDD and testing
-/java-reviewer  # Code review
+/java-coder
 ```
+
+Also activates automatically when writing, designing, or refactoring Java code (.java files, REST API design, JPA entity modeling, domain modeling).

--- a/plugins/java-coder/skills/java-coder/SKILL.md
+++ b/plugins/java-coder/skills/java-coder/SKILL.md
@@ -6,6 +6,7 @@ description: >
   JPA entity modeling, or domain modeling.
   NOT for test file writing (java-tester), code review (java-reviewer),
   Java 25 features (java-25), or Spring Boot patterns (spring).
+user_invocable: true
 ---
 
 # Java Coder — Integrated Guide (11-Book Edition)

--- a/plugins/java-reviewer/.claude-plugin/plugin.json
+++ b/plugins/java-reviewer/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "java-reviewer",
+  "version": "0.0.1",
+  "description": "Java code review checklists — Code Quality, DDD/Architecture, Effective Java, Stability/Production Readiness, and Spring Boot/API",
+  "author": {
+    "name": "ppzxc",
+    "email": "cjh8487@naver.com",
+    "url": "https://ppzxc.github.io"
+  }
+}

--- a/plugins/java-reviewer/README.ko.md
+++ b/plugins/java-reviewer/README.ko.md
@@ -1,0 +1,28 @@
+# java-reviewer
+
+Java 코드 리뷰 체크리스트 스킬입니다.
+
+## 포함 내용
+
+1. **코드 품질** — Virtual Thread 안전성, null 처리, DTO 구조, record 활용
+2. **DDD / 아키텍처** — 레이어 배치, 의존성 방향, Aggregate 규칙, 도메인 행위
+3. **Effective Java** — Static factory/Builder, 불변성, Optional 사용, enum 상수
+4. **안정성 / 프로덕션 준비** — 타임아웃, Circuit Breaker, Retry, 입력 검증
+5. **Spring Boot / API** — 생성자 주입, ProblemDetail, API 버전 관리, 트랜잭션 규칙
+
+## 설치
+
+```bash
+/plugin marketplace add ppzxc/java-plugins
+/plugin install java-reviewer
+```
+
+## 사용 방법
+
+설치 후 Claude Code에서 슬래시 커맨드로 스킬을 호출합니다:
+
+```
+/java-reviewer
+```
+
+Java 코드 리뷰, 품질 감사, 아키텍처 준수 확인 시 자동으로 활성화됩니다.

--- a/plugins/java-reviewer/README.md
+++ b/plugins/java-reviewer/README.md
@@ -1,0 +1,28 @@
+# java-reviewer
+
+A Java code review checklist skill for Claude Code.
+
+## Contents
+
+1. **Code Quality** — Virtual Thread safety, null handling, DTO structure, record usage
+2. **DDD / Architecture** — Layer placement, dependency direction, aggregate rules, domain behavior
+3. **Effective Java** — Static factory/Builder, immutability, Optional usage, enum constants
+4. **Stability / Production Readiness** — Timeouts, Circuit Breaker, Retry, input validation
+5. **Spring Boot / API** — Constructor injection, ProblemDetail, API versioning, transaction rules
+
+## Installation
+
+```bash
+/plugin marketplace add ppzxc/java-plugins
+/plugin install java-reviewer
+```
+
+## Usage
+
+Invoke as a slash command in Claude Code:
+
+```
+/java-reviewer
+```
+
+Also activates automatically when reviewing Java code, auditing code quality, or checking architecture compliance.

--- a/plugins/java-reviewer/skills/java-reviewer/SKILL.md
+++ b/plugins/java-reviewer/skills/java-reviewer/SKILL.md
@@ -6,6 +6,7 @@ description: >
   commands (/review, "review this code"), or multi-file quality audits.
   "PR review" means any code diff or multi-file review, not GitHub-specific tools.
   NOT for generating new code or writing tests.
+user_invocable: true
 ---
 
 # Java Reviewer
@@ -30,7 +31,7 @@ Review Java code for quality, architecture compliance, and production readiness.
 - [ ] No inner class/record → each DTO in its own file
 - [ ] Records used for DTOs and Value Objects
 
-**When found:** See `../java-coder/references/release-it-stability.md` (Virtual Thread safety) and `../java-coder/references/clean-and-pragmatic.md` (structure rules)
+**When found:** See `references/release-it-stability.md` (Virtual Thread safety) and `references/clean-and-pragmatic.md` (structure rules)
 
 **Refactoring techniques:**
 - `synchronized` → Replace with `ReentrantLock`; check for `ThreadLocal` in same class
@@ -46,7 +47,7 @@ Review Java code for quality, architecture compliance, and production readiness.
 - [ ] Aggregate accessed through root only — no direct child entity mutation
 - [ ] Domain objects carry behavior (no Anemic Domain Model)
 
-**When found:** See `../java-coder/references/domain-driven-design.md`
+**When found:** See `references/domain-driven-design.md`
 
 **Refactoring techniques:**
 - Layer violation → Extract Interface (keep interface in domain, move impl to infrastructure)
@@ -63,7 +64,7 @@ Review Java code for quality, architecture compliance, and production readiness.
 - [ ] `Optional` used only as return type — never as field or parameter
 - [ ] `enum` used instead of int constants
 
-**When found:** See `../java-coder/references/effective-java.md`
+**When found:** See `references/effective-java.md`
 
 **Refactoring techniques:**
 - Constructor with ≥4 params → Introduce Builder
@@ -82,7 +83,7 @@ Review Java code for quality, architecture compliance, and production readiness.
 - [ ] Redis/cache failure has auth-path fallback
 - [ ] Input validated at system boundary (controller/filter)
 
-**When found:** See `../java-coder/references/release-it-stability.md`
+**When found:** See `references/release-it-stability.md`
 
 **Refactoring techniques:**
 - Missing timeout → add `connectTimeout`/`readTimeout` to client config
@@ -101,10 +102,10 @@ Review Java code for quality, architecture compliance, and production readiness.
 
 | File | When to Open |
 |------|-------------|
-| `../java-coder/references/clean-and-pragmatic.md` | Naming, function size, structure rules |
-| `../java-coder/references/design-and-solid.md` | SOLID violations, GoF pattern misuse — consult when reviewing class dependencies, interface segregation, or design pattern usage |
-| `../java-coder/references/refactoring-catalog.md` | General refactoring technique lookup — consult when section guidance doesn't name the specific refactoring needed |
-| `../java-coder/references/effective-java.md` | EJ idiom violations |
-| `../java-coder/references/domain-driven-design.md` | DDD and architecture issues |
+| `references/clean-and-pragmatic.md` | Naming, function size, structure rules |
+| `references/design-and-solid.md` | SOLID violations, GoF pattern misuse — consult when reviewing class dependencies, interface segregation, or design pattern usage |
+| `references/refactoring-catalog.md` | General refactoring technique lookup — consult when section guidance doesn't name the specific refactoring needed |
+| `references/effective-java.md` | EJ idiom violations |
+| `references/domain-driven-design.md` | DDD and architecture issues |
 | **spring** skill | Spring annotation and API issues |
-| `../java-coder/references/release-it-stability.md` | Stability and Virtual Thread issues |
+| `references/release-it-stability.md` | Stability and Virtual Thread issues |

--- a/plugins/java-reviewer/skills/java-reviewer/references/clean-and-pragmatic.md
+++ b/plugins/java-reviewer/skills/java-reviewer/references/clean-and-pragmatic.md
@@ -1,0 +1,320 @@
+# Clean and Pragmatic Code (Clean Code + Pragmatic Programmer + Code Complete)
+
+## Table of Contents
+1. The Art of Naming
+2. Function/Method Design
+3. Comments and Self-Documenting Code
+4. Error Handling
+5. Classes and Data Structures
+6. Formatting and Code Organization
+7. Pragmatic Development Habits
+
+---
+
+## 1. The Art of Naming
+
+Names are the single most important factor that determines code readability.
+
+### Variable Names
+```java
+// Bad: Intent is hidden
+int d;  // elapsed time in days
+List<int[]> list1;
+
+// Good: Intent is clear
+int elapsedTimeInDays;
+List<Cell> flaggedCells;
+```
+
+### Method Names
+- Start with a verb or verb phrase: `save()`, `calculateTotal()`, `sendNotification()`
+- Boolean-returning methods: use `is`, `has`, `can`, `should` prefixes
+- Follow accessor/mutator/predicate conventions
+```java
+account.setBalance(amount);    // mutator
+account.getBalance();           // accessor
+account.isOverdrawn();          // predicate
+```
+
+### Class Names
+- Use nouns or noun phrases: `Customer`, `OrderProcessor`, `PaymentGateway`
+- Minimize vague suffixes like `Manager`, `Processor`, `Data`, `Info`
+- Meaningful distinctions: `ProductInfo` and `ProductData` should not coexist
+
+### Consistency
+- Same word for same concept: choose one of `fetch`/`retrieve`/`get` and use it project-wide
+- Similar names must not carry different meanings: `add` should not mean "append to collection" in one place and "sum values" in another
+
+---
+
+## 2. Function/Method Design
+
+### Size
+- Smaller is better. Ideally 5–15 lines
+- Should fit on one screen
+- Consider splitting when exceeding 20 lines
+
+### Do One Thing
+How to tell if a function does one thing: if you can extract a meaningfully named function from it, it's doing more than one thing.
+
+```java
+// Bad: Does multiple things at once
+public void processEmployee(Employee emp) {
+    validateEmployee(emp);
+    calculateSalary(emp);
+    saveToDB(emp);
+    sendPayslip(emp);
+    updateDashboard(emp);
+}
+
+// Good: Each does one thing, orchestrated by a higher-level function
+public void onboardEmployee(Employee emp) {
+    validateEmployee(emp);
+    processPayroll(emp);
+    notifyStakeholders(emp);
+}
+```
+
+### Uniform Abstraction Level (Stepdown Rule)
+Do not mix abstraction levels within a single function.
+High-level concepts and low-level details should not live in the same function.
+
+```java
+// Bad: Mixed abstraction levels
+public String renderPage() {
+    String html = "<html>";
+    html += getHeader();  // high level
+    html += "<div class=\"content\">";  // low level
+    html += getBody();  // high level
+    html += "</div>";  // low level
+    return html;
+}
+
+// Good: Uniform abstraction level
+public String renderPage() {
+    return buildHtmlDocument(
+        getHeader(),
+        wrapInContentDiv(getBody()),
+        getFooter()
+    );
+}
+```
+
+### Parameters
+- 0 (niladic) is best, 1 (monadic) is good, up to 2 (dyadic) is acceptable
+- 3+ parameters → wrap into an object
+- **Flag arguments are forbidden**: `render(boolean isSuite)` → `renderForSuite()`, `renderForSingle()`
+- Avoid output arguments: instead of `appendFooter(report)`, use `report.appendFooter()`
+
+### No Side Effects
+A function must do only what its name promises. `checkPassword()` should never initialize a session.
+
+---
+
+## 3. Comments and Self-Documenting Code
+
+### Good Comments (only when necessary)
+- Legal comments (copyright, license)
+- Intent explanation: why this approach was chosen
+- Warnings: `// Not thread-safe`
+- TODO: future work to address (should not be permanent)
+- Javadoc for public APIs
+
+### Bad Comments (replaceable with code)
+```java
+// Bad: Comment restates the code
+// Returns the employee's name
+public String getName() { return name; }
+
+// Bad: Change log (version control handles this)
+// 2024-01-15: Added discount logic - John Doe
+
+// Bad: Commented-out code (leave it to version control)
+// public void oldMethod() { ... }
+```
+
+### Self-Documenting Code
+When you feel a comment is needed, first ask if you can make the code clearer instead.
+```java
+// Code that needs a comment
+// Check if the employee is eligible for benefits
+if (employee.age > 65 && employee.yearsOfService > 20 && employee.isActive) { ... }
+
+// Self-documenting code
+if (employee.isEligibleForBenefits()) { ... }
+```
+
+---
+
+## 4. Error Handling
+
+### Exception Usage Principles
+- Use exceptions instead of return codes
+- Use checked exceptions only when necessary: when the caller can reasonably recover
+- Default to unchecked exceptions (programming errors, unrecoverable situations)
+- Include context information in exceptions
+
+```java
+// Bad: Exception without context
+throw new RuntimeException("Lookup failed");
+
+// Good: Sufficient context
+throw new OrderNotFoundException(
+    String.format("Order ID %d not found. Customer: %s", orderId, customerId)
+);
+```
+
+### Null Handling
+- **Do not return null**: return Optional or empty collections instead
+- **Do not pass null**: do not allow null as a method argument
+
+```java
+// Bad
+public List<Employee> findByDepartment(String dept) {
+    if (noResult) return null;
+}
+
+// Good
+public List<Employee> findByDepartment(String dept) {
+    if (noResult) return Collections.emptyList();
+}
+
+// For single-item lookups
+public Optional<Employee> findById(Long id) {
+    return Optional.ofNullable(repository.get(id));
+}
+```
+
+### Structuring try-catch
+- Write the try block first (think transactionally)
+- Never swallow exceptions in catch blocks (at minimum, log them)
+- Leverage try-with-resources
+
+```java
+try (var reader = new BufferedReader(new FileReader(path))) {
+    return reader.lines()
+        .map(this::parseLine)
+        .collect(Collectors.toList());
+} catch (IOException e) {
+    throw new DataLoadException("Failed to load file: " + path, e);
+}
+```
+
+---
+
+## 5. Classes and Data Structures
+
+### Class Organization Order (Java Convention)
+1. Static constants
+2. Static variables
+3. Instance variables (public → protected → private)
+4. Constructors
+5. Public methods
+6. Private methods (placed directly below the public method that calls them)
+
+### Cohesion
+Minimize instance variables, and have each method use as many instance variables as possible.
+Low cohesion is a signal to split the class.
+
+### Data Transfer Objects (DTO)
+- Carrying data without behavior is fine (DTO pattern)
+- But domain objects should carry behavior (avoid Anemic Domain Model)
+
+```java
+// DTO: For data transport — leverage records
+public record OrderSummaryDto(
+    Long orderId,
+    String customerName,
+    BigDecimal totalAmount,
+    LocalDateTime createdAt
+) {}
+
+// Domain Object: Has behavior
+public class Order {
+    private List<OrderItem> items;
+    private OrderStatus status;
+
+    public Money calculateTotal() { /* business logic */ }
+    public void cancel() { /* apply cancellation rules */ }
+    public boolean canBeModified() { /* modification condition */ }
+}
+```
+
+---
+
+## 6. Formatting and Code Organization
+
+### Vertical Formatting
+- Recommended file length: 200–500 lines (consider splitting beyond 500)
+- Related code stays close together, unrelated code stays apart
+- Callers are placed above callees (newspaper article order)
+- Separate concepts with blank lines
+
+### Horizontal Formatting
+- Stay within 120 characters per line (follow team rules)
+- Never skip indentation
+- Use spacing around operators to visualize precedence
+
+### Package Organization
+```
+com.company.project
+├── domain/          # Domain models, business logic
+├── application/     # Use cases, services
+├── infrastructure/  # DB, external API integration
+├── presentation/    # Controllers, DTOs
+└── common/          # Shared utilities
+```
+
+---
+
+## Cross-References
+
+- For Java-specific idioms that complement these principles (static factory, Builder, Optional) → `effective-java.md`
+- For DDD domain language that informs naming and domain object design → `domain-driven-design.md`
+
+---
+
+## 7. Pragmatic Development Habits
+
+### Orthogonality
+Maintain independence between modules. If changing A requires modifying B, they are not orthogonal.
+- Always ask when writing code: "What is the blast radius of this change?"
+
+### Tracer Bullet Development
+In uncertain projects, build a minimal working implementation that pierces through the entire architecture first.
+Connect a single line from UI → Service → DB end-to-end, then flesh it out.
+
+### Estimation
+- Provide ranges: "2–3 days" (not precise numbers)
+- Mind the units: 150 days → "about 6 months", 15 days → "about 3 weeks"
+- Keep estimation records and compare with actuals to improve accuracy
+
+### Domain Language
+Reflect the business domain's language in the code.
+For an accounting system, use `entry`, `ledger`, `debit`, `credit` in the code as well.
+
+### Design by Contract
+- **Preconditions**: Conditions that must hold before calling a function
+- **Postconditions**: Guaranteed state after a function completes
+- **Class invariants**: Conditions that must always hold true
+
+```java
+public class BankAccount {
+    private BigDecimal balance;  // Invariant: balance >= 0
+
+    public void withdraw(BigDecimal amount) {
+        // Precondition
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Withdrawal amount must be positive");
+        }
+        if (amount.compareTo(balance) > 0) {
+            throw new InsufficientFundsException("Insufficient funds");
+        }
+
+        balance = balance.subtract(amount);
+
+        // Postcondition (defensive programming)
+        assert balance.compareTo(BigDecimal.ZERO) >= 0 : "Balance became negative";
+    }
+}
+```

--- a/plugins/java-reviewer/skills/java-reviewer/references/design-and-solid.md
+++ b/plugins/java-reviewer/skills/java-reviewer/references/design-and-solid.md
@@ -1,0 +1,336 @@
+# Design Principles and Design Patterns (SOLID + GoF Design Patterns)
+
+## Table of Contents
+1. SOLID Principles In Depth
+2. Frequently Used Design Patterns in Java
+3. Pattern Selection Guide
+4. Anti-Pattern Avoidance
+
+---
+
+## 1. SOLID Principles In Depth
+
+### SRP (Single Responsibility Principle)
+
+If a class has more than one reason to change, it violates SRP.
+
+**Violation example:**
+```java
+// Bad: Two responsibilities — order processing and email sending
+public class OrderService {
+    public void processOrder(Order order) { /* order logic */ }
+    public void sendConfirmationEmail(Order order) { /* email logic */ }
+}
+```
+
+**Improved:**
+```java
+public class OrderProcessor {
+    public void process(Order order) { /* order logic only */ }
+}
+
+public class OrderNotifier {
+    public void sendConfirmation(Order order) { /* notification logic only */ }
+}
+```
+
+**Judgment criteria**: If you cannot describe why this class might change in a single sentence, split it.
+
+### OCP (Open-Closed Principle)
+
+New features should be addable without modifying existing code.
+
+**Key strategy**: Create extension points through abstractions (interfaces / abstract classes).
+
+```java
+// OCP applied: Adding a new discount policy requires no change to existing code
+public interface DiscountPolicy {
+    Money calculateDiscount(Order order);
+}
+
+public class PercentageDiscount implements DiscountPolicy {
+    private final double rate;
+    public PercentageDiscount(double rate) { this.rate = rate; }
+    public Money calculateDiscount(Order order) {
+        return order.getTotalPrice().multiply(rate);
+    }
+}
+
+// Adding a new policy: just add a new class, no existing code modified
+public class BulkDiscount implements DiscountPolicy {
+    public Money calculateDiscount(Order order) {
+        if (order.getItemCount() > 10) {
+            return order.getTotalPrice().multiply(0.15);
+        }
+        return Money.ZERO;
+    }
+}
+```
+
+**Java 25: sealed interface로 닫힌 계층 + pattern matching switch (OCP 강화)**
+```java
+// 허용된 구현체를 컴파일 타임에 고정 — 새 구현 추가 시 switch가 컴파일 에러로 알려줌
+public sealed interface DiscountPolicy permits PercentageDiscount, BulkDiscount {
+    Money calculateDiscount(Order order);
+}
+
+public record PercentageDiscount(double rate) implements DiscountPolicy {
+    public Money calculateDiscount(Order order) {
+        return order.getTotalPrice().multiply(rate);
+    }
+}
+
+public record BulkDiscount(int threshold, double discountRate) implements DiscountPolicy {
+    public Money calculateDiscount(Order order) {
+        return order.getItemCount() > threshold
+            ? order.getTotalPrice().multiply(discountRate)
+            : Money.ZERO;
+    }
+}
+
+// Exhaustive switch — permits 목록에 없는 타입 추가 시 컴파일 에러
+Money discount = switch (policy) {
+    case PercentageDiscount p -> p.calculateDiscount(order);
+    case BulkDiscount b -> b.calculateDiscount(order);
+};
+```
+
+### LSP (Liskov Substitution Principle)
+
+Subtypes must work correctly wherever their base type is used.
+
+**Classic signs of violation:**
+- Overriding a method with an empty implementation in a subclass
+- Growing number of `instanceof` checks
+- Subtype violating preconditions/postconditions of the base type
+
+**Principle**: Favor composition over inheritance. Verify that the "is-a" relationship holds behaviorally, not just structurally.
+
+### ISP (Interface Segregation Principle)
+
+Split bloated interfaces by role.
+
+```java
+// Bad: An interface that knows everything
+public interface Worker {
+    void work();
+    void eat();
+    void sleep();
+}
+
+// Good: Segregated by role
+public interface Workable { void work(); }
+public interface Feedable { void eat(); }
+public interface Restable { void sleep(); }
+
+public class HumanWorker implements Workable, Feedable, Restable { ... }
+public class RobotWorker implements Workable { ... }  // Doesn't eat or sleep
+```
+
+### DIP (Dependency Inversion Principle)
+
+High-level modules should not depend directly on low-level modules. Both should depend on abstractions.
+
+```java
+// Bad: High-level depends directly on low-level
+public class OrderService {
+    private MySQLOrderRepository repository = new MySQLOrderRepository();
+}
+
+// Good: Depends on abstraction + constructor injection
+public class OrderService {
+    private final OrderRepository repository;
+
+    public OrderService(OrderRepository repository) {
+        this.repository = repository;
+    }
+}
+```
+
+---
+
+## 2. Frequently Used Design Patterns in Java
+
+### Creational Patterns
+
+**Builder** — Step-by-step construction of complex objects
+- When constructor parameters exceed 4
+- When there are many optional parameters
+- When building immutable objects
+
+```java
+public class User {
+    private final String name;        // required
+    private final String email;       // required
+    private final int age;            // optional
+    private final String phone;       // optional
+
+    private User(Builder builder) {
+        this.name = builder.name;
+        this.email = builder.email;
+        this.age = builder.age;
+        this.phone = builder.phone;
+    }
+
+    public static class Builder {
+        private final String name;
+        private final String email;
+        private int age;
+        private String phone;
+
+        public Builder(String name, String email) {
+            this.name = name;
+            this.email = email;
+        }
+
+        public Builder age(int age) { this.age = age; return this; }
+        public Builder phone(String phone) { this.phone = phone; return this; }
+        public User build() { return new User(this); }
+    }
+}
+```
+
+**Java 25: 파라미터가 모두 필수·불변이면 record로 충분**
+```java
+// 모든 필드가 필수이고 불변이면 Builder 불필요
+public record User(String name, String email, int age, String phone) {}
+
+// Builder가 여전히 필요한 경우:
+// - optional 파라미터가 많을 때 (null 대신 기본값 세팅)
+// - 빌드 시 복잡한 유효성 검증이 필요할 때
+// - 단계적(Step Builder) 빌드가 필요할 때
+```
+
+**Factory Method** — Delegate object creation logic to subclasses
+- When the concrete type to create is determined at runtime
+- When creation logic is complex and repeated in multiple places
+
+**Singleton** — Use with great caution
+- Creates global state that makes testing difficult
+- If needed, prefer enum-based singletons or DI framework scoping
+
+### Structural Patterns
+
+**Adapter** — Connect incompatible interfaces
+- Bridge between legacy code and new code
+- Fit external libraries to internal interfaces
+
+**Decorator** — Dynamically add functionality
+- Extend responsibilities without inheritance
+- Java I/O streams are the classic example (`BufferedInputStream`)
+
+**Facade** — Provide a simple interface to a complex subsystem
+- Library wrapping, simplifying module boundaries
+
+### Behavioral Patterns
+
+**Strategy** — Encapsulate algorithms to make them interchangeable
+- When if-else/switch chains grow long
+- When algorithms need to be swapped at runtime
+
+```java
+public interface SortStrategy {
+    <T extends Comparable<T>> List<T> sort(List<T> items);
+}
+
+public class DataProcessor {
+    private SortStrategy strategy;
+
+    public DataProcessor(SortStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    public void setStrategy(SortStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    public <T extends Comparable<T>> List<T> process(List<T> data) {
+        return strategy.sort(data);
+    }
+}
+```
+
+**Java 25: sealed interface + pattern matching으로 타입 안전한 전략 분기**
+```java
+public sealed interface SortStrategy permits QuickSort, MergeSort, TimSort {
+    <T extends Comparable<T>> List<T> sort(List<T> items);
+}
+
+public record QuickSort() implements SortStrategy { ... }
+public record MergeSort() implements SortStrategy { ... }
+public record TimSort() implements SortStrategy { ... }
+
+// 패턴 매칭으로 전략별 설명 분기 (컴파일 타임 exhaustiveness 보장)
+String description = switch (strategy) {
+    case QuickSort q -> "Quick sort: O(n log n) average, in-place";
+    case MergeSort m -> "Merge sort: O(n log n) stable";
+    case TimSort t -> "Tim sort: hybrid, Python/Java default";
+};
+```
+
+**Observer** — Automatically notify dependents on state change
+- Event-driven systems, UI updates
+
+**Template Method** — Define algorithm skeleton, defer specific steps to subclasses
+- When a common workflow has only a few varying steps
+
+---
+
+## 3. Pattern Selection Guide
+
+| Problem Situation | Recommended Pattern |
+|-------------------|-------------------|
+| Complex object creation or many parameters | Builder, Factory Method |
+| Conditionals branching on type | Strategy, State |
+| Extend existing code without modification | Decorator, Adapter |
+| Multiple objects must react to state changes | Observer |
+| Need to simplify a complex API | Facade |
+| Same algorithm skeleton, different details | Template Method |
+| Traverse an object structure and perform operations | Iterator, Visitor |
+
+**Ask before applying a pattern:**
+1. Does this problem truly require a pattern?
+2. Is there a simpler solution?
+3. Does the team understand this pattern?
+
+---
+
+## Cross-References
+
+- For DDD tactical patterns that operationalize these principles (Aggregate, Repository, Domain Service) → `domain-driven-design.md`
+- For Effective Java idioms that implement these patterns in Java (Builder, enum Strategy, interfaces) → `effective-java.md`
+
+---
+
+## 4. Anti-Pattern Avoidance
+
+- **God Object**: A class that knows everything → Decompose via SRP
+- **Anemic Domain Model**: Models with only getters/setters → Put behavior in domain objects
+- **Premature Optimization**: Optimizing without measuring → Make it correct first, then fast
+- **Cargo Cult Programming**: Applying patterns without reason → Understand the problem first
+- **Golden Hammer**: Trying to solve every problem with one pattern/technology → Choose the right tool for the problem
+
+**instanceof 체인 → sealed + pattern matching switch**
+```java
+// Anti-pattern: 타입 체크 체인 (새 타입 추가 시 모든 분기 찾아야 함)
+if (shape instanceof Circle) {
+    var c = (Circle) shape;
+    return Math.PI * c.radius() * c.radius();
+} else if (shape instanceof Rectangle) {
+    var r = (Rectangle) shape;
+    return r.width() * r.height();
+}
+
+// Modern Java: sealed + pattern matching switch (exhaustive, 컴파일 타임 안전)
+sealed interface Shape permits Circle, Rectangle, Triangle {}
+record Circle(double radius) implements Shape {}
+record Rectangle(double width, double height) implements Shape {}
+record Triangle(double base, double height) implements Shape {}
+
+double area = switch (shape) {
+    case Circle(var r) -> Math.PI * r * r;
+    case Rectangle(var w, var h) -> w * h;
+    case Triangle(var b, var h) -> 0.5 * b * h;
+};
+// Shape에 새 permits 타입 추가 시 switch에 컴파일 에러 → 누락 불가
+```

--- a/plugins/java-reviewer/skills/java-reviewer/references/domain-driven-design.md
+++ b/plugins/java-reviewer/skills/java-reviewer/references/domain-driven-design.md
@@ -1,0 +1,524 @@
+# Domain-Driven Design — Patterns and Modular Monolith Mapping
+
+Based on *Domain-Driven Design* by Eric Evans and *Implementing Domain-Driven Design* by Vaughn Vernon.
+Adapted for Modular Monolith architecture with Java 25 + Spring Boot 4.
+
+## Table of Contents
+1. Strategic Design
+2. Tactical Design — Building Blocks
+3. Module Mapping
+4. Aggregate Design Rules
+5. Domain Events
+6. Ubiquitous Language
+7. Anti-Corruption Layer
+8. Common Pitfalls
+
+---
+
+## 1. Strategic Design
+
+### Bounded Context
+
+A Bounded Context is a boundary within which a domain model applies consistently. Each context has its own Ubiquitous Language — the same word can mean different things in different contexts.
+
+**Example Bounded Contexts (e-commerce Modular Monolith)**
+
+| Context | Responsibility | Key Aggregates |
+|---------|---------------|----------------|
+| `identity` | Users, authentication, sessions | `User` |
+| `catalog` | Products, categories, pricing | `Product`, `Category` |
+| `ordering` | Orders, order lines, checkout | `Order`, `OrderLineItem` |
+| `shipping` | Shipments, tracking, fulfillment | `Shipment` |
+| `payment` | Payment processing, refunds | `Payment` |
+
+In a Modular Monolith, Bounded Contexts map to **packages within modules**, not separate services.
+
+### Context Mapping
+
+How Bounded Contexts relate to each other:
+
+| Pattern | When to Use | Example |
+|---------|------------|---------|
+| Shared Kernel | Two contexts share a model fragment | `customerId` referenced in multiple contexts |
+| Customer-Supplier | One context drives another | `catalog` drives `ordering` (product prices) |
+| Anti-Corruption Layer | Translate external model to internal | Payment gateway payload → `PaymentReceivedCommand` |
+| Open Host Service | Provide a stable API for other contexts | `OrderService` API consumed by `shipping` |
+
+### Ubiquitous Language
+
+Every concept in the codebase must use the same term as the domain expert uses.
+
+**Rule**: When you hear a new term from a product discussion, add it to a project glossary and update code names before writing new code.
+
+```java
+// Bad: generic terms that don't reflect the domain
+class Thing { ... }
+void doStuff(User u) { ... }
+
+// Good: domain terms that match stakeholder vocabulary
+class Order { ... }
+void fulfillOrder(CustomerId customerId) { ... }
+```
+
+---
+
+## 2. Tactical Design — Building Blocks
+
+### Entity
+
+Has identity that persists over time and across state changes.
+
+```java
+@Entity
+@Table(name = "orders")
+public class Order {
+  @Id
+  @Column(name = "id", columnDefinition = "uuid")
+  private UUID id;                        // Identity — never changes
+
+  @Column(name = "customer_id", nullable = false)
+  private UUID customerId;
+
+  @Enumerated(EnumType.STRING)
+  private OrderStatus status;             // Mutable state
+
+  // Behavior methods (not just getters/setters)
+  public void confirm() {
+    if (this.status != OrderStatus.PENDING) {
+      throw new OrderAlreadyConfirmedException(this.id);
+    }
+    this.status = OrderStatus.CONFIRMED;
+    registerEvent(new OrderConfirmedEvent(this.id, customerId, Instant.now()));
+  }
+}
+```
+
+**Rules**:
+- Identity (`@Id`) never changes after creation
+- Equality based on identity only, not state
+- Behavior goes in the entity, not in a service (avoid Anemic Domain Model)
+
+### Value Object
+
+No identity. Defined entirely by its attributes. Always immutable.
+
+```java
+// Good: Java record as Value Object
+public record Money(BigDecimal amount, Currency currency) {
+  public Money {
+    Objects.requireNonNull(amount, "amount required");
+    Objects.requireNonNull(currency, "currency required");
+    if (amount.compareTo(BigDecimal.ZERO) < 0) {
+      throw new IllegalArgumentException("Amount must be non-negative");
+    }
+  }
+
+  public Money add(Money other) {
+    if (!this.currency.equals(other.currency)) {
+      throw new IllegalArgumentException("Currency mismatch");
+    }
+    return new Money(this.amount.add(other.amount), this.currency);
+  }
+}
+
+// Value Objects as JPA embeddable
+@Embeddable
+public record Address(
+    @Column(name = "street") String street,
+    @Column(name = "city") String city,
+    @Column(name = "postal_code") String postalCode
+) {}
+```
+
+**Rules**:
+- No `@Id` field
+- Equality based on all attributes (records give this for free)
+- Replace primitives with Value Objects when the primitive has invariants
+- Side-effect-free methods only (return new VO, don't mutate)
+
+### Aggregate
+
+A cluster of Entities and Value Objects with a single root Entity (Aggregate Root) that enforces invariants for the whole cluster.
+
+```java
+public class Order {  // Aggregate Root
+  private UUID id;
+  private UUID customerId;
+  private List<OrderLineItem> lineItems = new ArrayList<>();  // child entities
+  private OrderStatus status;
+
+  // All modifications through root
+  public OrderLineItem addLineItem(ProductId productId, int quantity, Money unitPrice) {
+    validateNotConfirmed();
+    var lineItem = OrderLineItem.create(this.id, productId, quantity, unitPrice);
+    lineItems.add(lineItem);
+    return lineItem;
+  }
+
+  // Invariant enforced here, not in service
+  private void validateNotConfirmed() {
+    if (status != OrderStatus.PENDING) {
+      throw new OrderAlreadyConfirmedException(id);
+    }
+  }
+
+  public Money calculateTotal() {
+    return lineItems.stream()
+        .map(OrderLineItem::subtotal)
+        .reduce(Money.ZERO, Money::add);
+  }
+}
+```
+
+**Rules** (see §4 for the full list):
+- Only the Aggregate Root has a repository
+- External objects hold only the ID of another aggregate (not a reference)
+- One transaction = one aggregate (usually)
+
+### Repository
+
+Provides persistence for exactly one Aggregate Root. The interface belongs in the **domain module**; the implementation in the **infrastructure module**.
+
+```java
+// Interface in domain module
+public interface OrderRepository {
+  Optional<Order> findById(UUID id);
+  Optional<Order> findByIdAndCustomerId(UUID id, UUID customerId);
+  Order save(Order order);
+  void deleteById(UUID id);
+}
+
+// Implementation in infrastructure module
+@Repository
+public class JpaOrderRepository implements OrderRepository {
+  private final OrderJpaRepository jpa;  // Spring Data JPA
+
+  @Override
+  public Optional<Order> findByIdAndCustomerId(UUID id, UUID customerId) {
+    return jpa.findByIdAndCustomerId(id, customerId);
+  }
+}
+```
+
+### Domain Service
+
+Logic that doesn't naturally belong in an Entity or Value Object, typically coordinating multiple aggregates.
+
+```java
+// In domain module: stateless, no infrastructure dependencies
+public interface OrderFulfillmentService {
+  void fulfill(UUID orderId, UUID warehouseId);
+}
+
+// In application module: uses repositories and other services
+@Service
+public class OrderFulfillmentServiceImpl implements OrderFulfillmentService {
+  private final OrderRepository orderRepo;
+  private final InventoryRepository inventoryRepo;
+
+  @Transactional
+  public void fulfill(UUID orderId, UUID warehouseId) {
+    var order = orderRepo.findById(orderId)
+        .orElseThrow(() -> new OrderNotFoundException(orderId));
+    var inventory = inventoryRepo.findByWarehouseId(warehouseId)
+        .orElseThrow(() -> new InventoryNotFoundException(warehouseId));
+    order.markFulfilled();
+    inventory.reserveItems(order.getLineItems());
+    orderRepo.save(order);
+    inventoryRepo.save(inventory);
+  }
+}
+```
+
+**When to use Domain Service** (not Entity):
+- Requires access to multiple aggregates
+- Would be unnatural to put in either aggregate
+- Conceptually a "verb" not a "noun" (e.g., `Transfer`, `Fulfill`, `Merge`)
+
+### Application Service (Use Case)
+
+Orchestrates domain objects to fulfill a use case. Lives in the application/service module. Has no domain logic.
+
+```java
+@Service
+@RequiredArgsConstructor
+public class PlaceOrderUseCase {
+  private final OrderRepository orderRepo;
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Transactional
+  public OrderResponse execute(PlaceOrderCommand command) {
+    // 1. Load or create aggregate
+    var order = Order.create(command.customerId());
+
+    // 2. Delegate to domain
+    command.lineItems().forEach(item ->
+        order.addLineItem(item.productId(), item.quantity(), item.unitPrice()));
+
+    // 3. Persist
+    orderRepo.save(order);
+
+    // 4. Publish events
+    order.getDomainEvents().forEach(eventPublisher::publishEvent);
+
+    return OrderResponse.from(order);
+  }
+}
+```
+
+---
+
+## 3. Module Mapping
+
+```
+<app>-domain                         <app>-application (or -service)
+  com.example.order                    com.example.order
+    Order.java (Entity)                  OrderService.java (interface)
+    OrderLineItem.java (Entity)          OrderServiceImpl.java
+    OrderStatus.java (enum)              PlaceOrderCommand.java (record)
+    OrderRepository.java (interface)     OrderResponse.java (record)
+    Money.java (VO)
+    OrderConfirmedEvent.java
+
+  com.example.customer                 com.example.customer
+    Customer.java                        CustomerService.java
+    CustomerRepository.java              ...
+
+<app>-infrastructure                 <app>-api (presentation)
+  com.example.infra.order              com.example.order
+    JpaOrderRepository.java              OrderController.java
+    OrderJpaRepository.java              (uses service, never domain directly)
+```
+
+### Dependency Rules
+
+```
+api / presentation  → application (Application Service interfaces)
+application         → domain      (Domain model, Repository interfaces)
+infrastructure      → domain      (Implements Repository interfaces)
+common              ← (all modules depend on common)
+
+FORBIDDEN: application → infrastructure
+FORBIDDEN: domain      → application
+FORBIDDEN: domain      → infrastructure
+```
+
+---
+
+## 4. Aggregate Design Rules
+
+### Rule 1: Reference Other Aggregates by Identity Only
+
+```java
+// Bad: holds reference to another Aggregate
+public class Order {
+  private Customer customer;  // full Aggregate reference
+}
+
+// Good: holds only ID
+public class Order {
+  private UUID customerId;  // ID reference only
+}
+```
+
+### Rule 2: Enforce Invariants Within the Aggregate
+
+```java
+public class Order {
+  private final int maxLineItems;
+  private final List<OrderLineItem> lineItems;
+
+  public void addLineItem(ProductId productId, int quantity, Money unitPrice) {
+    if (lineItems.size() >= maxLineItems) {
+      throw new OrderLineItemLimitExceededException(id, maxLineItems);
+    }
+    lineItems.add(OrderLineItem.create(id, productId, quantity, unitPrice));
+  }
+}
+```
+
+### Rule 3: One Transaction = One Aggregate (as a guideline)
+
+When you need to update two aggregates in one use case, consider:
+1. Can the second aggregate be updated eventually (via Domain Event)?
+2. Is there a missing aggregate that encompasses both?
+3. If truly necessary, use explicit `@Transactional` and document the reason.
+
+### Rule 4: Small Aggregates
+
+Large aggregates cause contention. If loading an Aggregate loads thousands of child entities, redesign.
+
+```java
+// Bad: loads ALL line items eagerly
+public class Order {
+  @OneToMany(fetch = FetchType.EAGER)
+  private List<OrderLineItem> allLineItems;  // could be thousands
+}
+
+// Good: OrderLineItem is its own Aggregate Root with reference to Order
+public class OrderLineItem {
+  private UUID id;
+  private UUID orderId;  // reference by ID
+}
+```
+
+---
+
+## 5. Domain Events
+
+Domain Events represent something that happened in the domain. They are immutable facts.
+
+```java
+// Domain Event definition (domain module)
+public record OrderCompletedEvent(
+    UUID orderId,
+    UUID customerId,
+    Money totalAmount,
+    Instant occurredAt
+) implements DomainEvent {}
+
+// Publishing from Aggregate Root
+public class Order extends AbstractAggregateRoot<Order> {
+  public void complete() {
+    this.status = OrderStatus.DELIVERED;
+    registerEvent(new OrderCompletedEvent(id, customerId, calculateTotal(), Instant.now()));
+  }
+}
+
+// Handling in Application Service
+@Service
+public class OrderEventHandler {
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onOrderCompleted(OrderCompletedEvent event) {
+    // Send confirmation email, update analytics, trigger loyalty points, etc.
+    // Runs AFTER the transaction that published the event commits
+  }
+}
+```
+
+### Event Naming
+
+Events are named in past tense: `OrderPlaced`, `OrderConfirmed`, `OrderShipped`, `OrderCompleted`, `PaymentReceived`.
+
+---
+
+## 6. Ubiquitous Language in Code
+
+### Map Domain Terms to Code
+
+Identify domain terms with stakeholders and map them directly to code names. Terms should be consistent across conversations, documentation, and code.
+
+```java
+// Example e-commerce glossary → code mapping
+// "order" → Order, OrderRepository, OrderService
+// "line item" → OrderLineItem (not "cart item" or "product line")
+// "customer" → Customer (not "user" or "buyer" in order context)
+// "fulfillment" → OrderFulfillment, FulfillOrderCommand
+```
+
+### Enforce Language Through Types
+
+```java
+// Bad: primitive obsession loses domain meaning
+void assign(UUID id1, UUID id2) { ... }
+
+// Good: types carry meaning
+void ship(OrderId orderId, ShipmentId shipmentId) { ... }
+```
+
+### Project Glossary Pattern
+
+Maintain a `GLOSSARY.md` or wiki entry per Bounded Context listing:
+- **Term**: The domain word
+- **Code name**: The Java class/method/field name
+- **Forbidden synonyms**: Words that must not be used instead
+
+---
+
+## 7. Anti-Corruption Layer
+
+Used when integrating external systems (webhooks, third-party APIs) to translate their model into your domain model.
+
+```java
+// External payment webhook payload (external model)
+public record StripeWebhookPayload(
+    String type,
+    String paymentIntentId,
+    long amountReceived,
+    String currency,
+    String status
+) {}
+
+// Anti-Corruption Layer translation
+@Component
+public class StripeWebhookTranslator {
+  public PaymentReceivedCommand translate(StripeWebhookPayload payload) {
+    return new PaymentReceivedCommand(
+        payload.paymentIntentId(),
+        Money.of(BigDecimal.valueOf(payload.amountReceived(), 2),
+                 Currency.getInstance(payload.currency().toUpperCase())),
+        Instant.now()
+    );
+  }
+}
+
+// Domain Command (your model)
+public record PaymentReceivedCommand(
+    String externalPaymentId,
+    Money amount,
+    Instant receivedAt
+) {}
+```
+
+---
+
+## 8. Common Pitfalls
+
+### Anemic Domain Model
+
+```java
+// Bad: Entity is just a data bag
+public class Order {
+  private OrderStatus status;
+  public OrderStatus getStatus() { return status; }
+  public void setStatus(OrderStatus status) { this.status = status; }
+}
+
+// Bad: All logic in service
+orderService.setStatus(id, CONFIRMED);  // service does everything
+
+// Good: Behavior in entity, invariants enforced
+order.confirm();  // entity validates + emits event
+```
+
+### Transaction Script Leaking into Domain
+
+```java
+// Bad: Domain object depends on repository
+public class Order {
+  @Autowired OrderRepository repo;  // never inject infra into domain
+
+  public void confirm() {
+    this.status = CONFIRMED;
+    repo.save(this);  // domain should not know about persistence
+  }
+}
+```
+
+### Exposing Internal Aggregate Structure
+
+```java
+// Bad: returns mutable internal list
+public List<OrderLineItem> getLineItems() { return lineItems; }
+
+// Good: return unmodifiable view or DTO
+public List<OrderLineItem> getLineItems() { return Collections.unmodifiableList(lineItems); }
+```
+
+---
+
+## Cross-References
+
+- For SOLID principles that complement DDD → `design-and-solid.md`
+- For Effective Java patterns used in Value Objects and Builders → `effective-java.md`
+- For stability patterns for Domain Event publishing → `release-it-stability.md`

--- a/plugins/java-reviewer/skills/java-reviewer/references/effective-java.md
+++ b/plugins/java-reviewer/skills/java-reviewer/references/effective-java.md
@@ -1,0 +1,502 @@
+# Effective Java — Core Idioms and Best Practices
+
+Based on *Effective Java* (3rd edition) by Joshua Bloch. Items most relevant to Java 25 + Spring Boot 4 projects.
+
+## Table of Contents
+1. Object Creation
+2. Immutability and Defensive Copying
+3. Generics
+4. Enums and Annotations
+5. Streams and Lambdas
+6. Optional
+7. Concurrency (Virtual Thread context)
+8. Interfaces and Design
+
+---
+
+## 1. Object Creation
+
+### Prefer Static Factory Methods over Constructors (Item 1)
+
+Static factories have names, can return cached instances, and can return subtypes.
+
+```java
+// Bad: constructor reveals nothing
+new OrderId(uuid);
+
+// Good: intent is clear
+OrderId.of(uuid);
+OrderId.fromString("550e8400-...");
+
+// Cached instance (e.g., known enum-like values)
+public static final OrderStatus PENDING = new OrderStatus("PENDING");
+public static OrderStatus of(String code) {
+  return REGISTRY.computeIfAbsent(code, OrderStatus::new);
+}
+```
+
+Common naming conventions: `of`, `from`, `valueOf`, `getInstance`, `newInstance`, `create`, `get<Type>`.
+
+### Builder for Complex Objects (Item 2)
+
+Use when a class has ≥4 parameters or many optional fields. Lombok `@Builder` is acceptable; hand-rolled builder for domain objects needing validation.
+
+```java
+// Domain object with validation in builder
+public final class CreateOrderCommand {
+  private final UUID customerId;    // required
+  private final String itemCode;    // required
+  private final int quantity;       // required
+  private final String couponCode;  // optional
+  private final UUID attachmentId;  // optional
+
+  private CreateOrderCommand(Builder b) { ... }
+
+  public static Builder builder() { return new Builder(); }
+
+  public static final class Builder {
+    // required fields as constructor params or explicit setters with validation
+    public CreateOrderCommand build() {
+      Objects.requireNonNull(customerId, "customerId required");
+      Objects.requireNonNull(itemCode, "itemCode required");
+      return new CreateOrderCommand(this);
+    }
+  }
+}
+```
+
+### Avoid Creating Unnecessary Objects (Item 6)
+
+```java
+// Bad: new String on every call
+String s = new String("hello");
+
+// Good: literal reuse
+String s = "hello";
+
+// Bad: autoboxing in tight loop
+Long sum = 0L;
+for (long i = 0; i < 1_000_000; i++) sum += i;  // boxes each addition
+
+// Good: primitive
+long sum = 0L;
+```
+
+### Eliminate Obsolete Object References (Item 7)
+
+Null out references in stack-like structures when elements are popped. Be careful with caches — use `WeakHashMap` or time-based eviction.
+
+### Prefer try-with-resources (Item 9)
+
+```java
+// Always for Closeable resources
+try (var conn = dataSource.getConnection();
+     var stmt = conn.prepareStatement(SQL)) {
+  // use resources
+} // both auto-closed, even if exception
+```
+
+---
+
+## 2. Immutability and Defensive Copying
+
+### Minimize Mutability (Item 17)
+
+Five rules for immutable classes:
+1. No methods that modify state
+2. Class cannot be extended (`final` or private constructor + static factory)
+3. All fields `final`
+4. All fields `private`
+5. Exclusive access to mutable components (defensive copy)
+
+```java
+// Immutable Value Object using record (Java 16+)
+public record PhoneNumber(String e164) {
+  public PhoneNumber {
+    Objects.requireNonNull(e164);
+    if (!e164.matches("\\+[1-9]\\d{1,14}")) {
+      throw new IllegalArgumentException("Not a valid E.164 number: " + e164);
+    }
+  }
+}
+```
+
+If a class cannot be made fully immutable, limit mutability as much as possible — make every field `final` unless there is a compelling reason to make it non-final.
+
+### Defensive Copies (Item 50)
+
+Copy mutable objects passed to or returned from a class.
+
+```java
+public final class Period {
+  private final Date start;
+  private final Date end;
+
+  public Period(Date start, Date end) {
+    // Defensive copy BEFORE validation — prevents TOCTOU attack
+    this.start = new Date(start.getTime());
+    this.end   = new Date(end.getTime());
+    if (this.start.after(this.end)) throw new IllegalArgumentException("start after end");
+  }
+
+  public Date start() { return new Date(start.getTime()); }  // defensive copy on return
+}
+```
+
+**Prefer `Instant`, `LocalDate`, `Duration`** (already immutable) over `Date`.
+
+### Composition over Inheritance (Item 18)
+
+Inheritance breaks encapsulation. Prefer delegation/composition when reusing behavior across classes that do not have a genuine is-a relationship.
+
+```java
+// Forwarding wrapper (composition)
+public class InstrumentedSet<E> implements Set<E> {
+  private final Set<E> delegate;
+  private int addCount = 0;
+
+  public InstrumentedSet(Set<E> s) { this.delegate = s; }
+
+  @Override public boolean add(E e) { addCount++; return delegate.add(e); }
+  // delegate all other Set methods to this.delegate
+}
+```
+
+---
+
+## 3. Generics
+
+### Don't Use Raw Types (Item 26)
+
+```java
+// Bad — raw type loses type safety
+List list = new ArrayList();
+list.add("text");
+
+// Good
+List<String> list = new ArrayList<>();
+```
+
+### Use Bounded Wildcards for Flexibility: PECS (Item 31)
+
+**P**roducer **E**xtends, **C**onsumer **S**uper
+
+```java
+// Producer (you read from it) — use extends
+public void pushAll(Iterable<? extends E> src) {
+  for (E e : src) push(e);
+}
+
+// Consumer (you write into it) — use super
+public void popAll(Collection<? super E> dst) {
+  while (!isEmpty()) dst.add(pop());
+}
+```
+
+### Prefer Generic Methods (Item 30)
+
+```java
+// Type-safe generic utility
+public static <E> Set<E> union(Set<E> s1, Set<E> s2) {
+  var result = new HashSet<>(s1);
+  result.addAll(s2);
+  return result;
+}
+```
+
+### Typesafe Heterogeneous Container (Item 33)
+
+When you need a map from type to instance of that type:
+
+```java
+public class Favorites {
+  private final Map<Class<?>, Object> favorites = new HashMap<>();
+
+  public <T> void putFavorite(Class<T> type, T instance) {
+    favorites.put(Objects.requireNonNull(type), instance);
+  }
+
+  public <T> T getFavorite(Class<T> type) {
+    return type.cast(favorites.get(type));
+  }
+}
+```
+
+---
+
+## 4. Enums and Annotations
+
+### Use Enums Instead of int Constants (Item 34)
+
+```java
+// Bad
+public static final int STATUS_PENDING  = 0;
+public static final int STATUS_SENT     = 1;
+
+// Good — type-safe, has namespace, printable
+public enum OrderStatus {
+  PENDING, CONFIRMED, SHIPPED, DELIVERED, CANCELLED;
+
+  public boolean isTerminal() {
+    return this == DELIVERED || this == CANCELLED;
+  }
+}
+```
+
+### Use EnumMap (Item 37)
+
+Prefer `EnumMap` over ordinal indexing; it is as fast as an array but type-safe.
+
+```java
+var ordersByStatus = new EnumMap<OrderStatus, List<Order>>(OrderStatus.class);
+```
+
+### Strategy Enum Pattern (Item 34)
+
+```java
+public enum RetryStrategy {
+  IMMEDIATE {
+    @Override public long delayMs(int attempt) { return 0; }
+  },
+  EXPONENTIAL_BACKOFF {
+    @Override public long delayMs(int attempt) { return (long) Math.pow(2, attempt) * 100; }
+  };
+
+  public abstract long delayMs(int attempt);
+}
+```
+
+### Annotations over Naming Conventions (Item 39)
+
+Use `@Override` on every method you intend to override. It catches bugs at compile time.
+
+---
+
+## 5. Streams and Lambdas
+
+### Use Streams Judiciously (Item 45)
+
+Streams excel at:
+- Transforming sequences (map, filter, flatMap)
+- Grouping and collecting (Collectors)
+- Finding elements (findFirst, anyMatch)
+
+Prefer loops when:
+- You need to modify local variables
+- You need to break/continue/return from an enclosing scope
+- You need checked exceptions
+
+### Prefer Method References over Lambdas (Item 43)
+
+```java
+// Lambda — acceptable
+list.stream().map(s -> s.toUpperCase())
+
+// Method reference — cleaner
+list.stream().map(String::toUpperCase)
+```
+
+### Use Standard Functional Interfaces (Item 44)
+
+`java.util.function` provides 43 interfaces; use them instead of inventing your own.
+
+| Interface | Signature | Example |
+|-----------|-----------|---------|
+| `Predicate<T>` | `T → boolean` | filter condition |
+| `Function<T,R>` | `T → R` | transform |
+| `Supplier<T>` | `() → T` | lazy factory |
+| `Consumer<T>` | `T → void` | log/notify |
+| `UnaryOperator<T>` | `T → T` | transform same type |
+
+### Prefer Side-Effect-Free Functions (Item 46)
+
+Stream operations should be pure functions. Side effects (DB writes, logging) belong in `forEach` at the terminal operation, not in intermediate ops.
+
+```java
+// Bad: side effect in intermediate map
+orders.stream()
+    .map(o -> { repository.save(o); return o; })  // don't
+    .collect(toList());
+
+// Good: collect first, then act
+var saved = orders.stream()
+    .map(repository::save)
+    .collect(toList());
+```
+
+### Collectors (Item 46)
+
+```java
+// Grouping
+var byStatus = orders.stream()
+    .collect(Collectors.groupingBy(Order::getStatus));
+
+// Joining
+var ids = ids.stream()
+    .map(UUID::toString)
+    .collect(Collectors.joining(", "));
+
+// Counting
+var countByStatus = orders.stream()
+    .collect(Collectors.groupingBy(Order::getStatus, Collectors.counting()));
+```
+
+---
+
+## 6. Optional
+
+### Optional as Return Type Only (Item 55)
+
+`Optional` is designed exclusively as a method return type to indicate a value that may be absent.
+
+```java
+// Good: return type
+public Optional<User> findByEmail(String email) { ... }
+
+// Bad: Optional field
+private Optional<String> nickname;  // Serialization issues, unnecessary overhead
+
+// Bad: Optional parameter
+public void process(Optional<String> name) { ... }  // Just use overloading or nullable
+
+// Bad: Optional in collection
+List<Optional<Order>> orders;  // Use List<Order> with absent items filtered out
+```
+
+### Return Empty Collections, Not Null (Item 54)
+
+```java
+// Bad
+public List<Order> findAll() {
+  if (noResults) return null;
+}
+
+// Good
+public List<Order> findAll() {
+  if (noResults) return Collections.emptyList();
+}
+```
+
+### Optional Combinators
+
+```java
+// orElse — always evaluated
+var name = findByEmail(email).orElse("Unknown");
+
+// orElseGet — lazy, evaluated only if empty (preferred for expensive defaults)
+var user = findById(id).orElseGet(() -> createGuestUser());
+
+// orElseThrow — throw if absent
+var order = findOrderById(id).orElseThrow(() -> new OrderNotFoundException(id));
+
+// map + flatMap
+var customerName = findOrder(orderId)
+    .map(Order::getCustomerId)
+    .flatMap(this::findCustomer)
+    .map(Customer::getName)
+    .orElse("Unknown customer");
+```
+
+---
+
+## 7. Concurrency (Virtual Thread Context)
+
+### Prefer Concurrency Utilities over wait/notify (Item 81)
+
+Use `java.util.concurrent` — `CountDownLatch`, `Semaphore`, `BlockingQueue`, `CompletableFuture`.
+Never implement your own synchronization primitives.
+
+### ReentrantLock over synchronized
+
+Virtual Threads are pinned when blocking inside a `synchronized` block. Use `ReentrantLock` instead.
+
+```java
+// Bad — pins Virtual Thread
+synchronized void process() { expensiveIO(); }
+
+// Good — Virtual Thread safe
+private final ReentrantLock lock = new ReentrantLock();
+
+void process() {
+  lock.lock();
+  try {
+    expensiveIO();
+  } finally {
+    lock.unlock();
+  }
+}
+```
+
+### ScopedValue over ThreadLocal (Item 83 analog, Java 25)
+
+`ThreadLocal` does not compose well with Virtual Threads and structured concurrency.
+
+```java
+// Bad — ThreadLocal leaks across Virtual Threads
+private static final ThreadLocal<RequestContext> CTX = new ThreadLocal<>();
+
+// Good — ScopedValue, bounded lifetime
+private static final ScopedValue<RequestContext> CTX = ScopedValue.newInstance();
+
+ScopedValue.where(CTX, requestContext).run(() -> {
+  // CTX is readable within this scope
+  processRequest();
+});
+```
+
+### Avoid Excessive Synchronization (Item 79)
+
+Do as little as possible inside synchronized regions. Never call alien methods (methods you don't control) while holding a lock — it can cause deadlocks or liveness failures.
+
+### Document Thread Safety (Item 82)
+
+Every class must document its thread-safety level:
+- `@Immutable` — always thread-safe
+- `@ThreadSafe` — safe for concurrent use
+- `@NotThreadSafe` — not safe
+
+---
+
+## 8. Interfaces and Design
+
+### Use Interfaces to Define Types (Item 41)
+
+Interfaces should define what a type can do, not accumulate constants.
+
+```java
+// Bad — constant interface anti-pattern
+public interface PhysicalConstants {
+  static final double AVOGADROS_NUMBER = 6.022_140_857e23;
+}
+
+// Good — constants in enum or utility class
+public enum PhysicalConstant {
+  AVOGADROS_NUMBER(6.022_140_857e23);
+  private final double value;
+  // ...
+}
+```
+
+### Design Interfaces for Posterity (Item 21)
+
+Default methods added to interfaces can break existing implementations. Test new default methods with at least three concrete implementations before releasing.
+
+### Use Abstract Classes for Skeletal Implementations (Item 20)
+
+When providing a non-trivial implementation alongside an interface, use the Template Method pattern with a `Abstract<Type>` class.
+
+```java
+public interface Repository<T, ID> { ... }
+public abstract class AbstractRepository<T, ID> implements Repository<T, ID> {
+  // Common CRUD implementation
+}
+public class JpaOrderRepository extends AbstractRepository<Order, UUID> { ... }
+```
+
+---
+
+## Cross-References
+
+- For DDD-aligned Value Object patterns → `domain-driven-design.md`
+- For Clean Code naming rules (complementary) → `clean-and-pragmatic.md`
+- For Java 25 records/sealed classes (modern EJ idioms) → `java25-features.md`

--- a/plugins/java-reviewer/skills/java-reviewer/references/refactoring-catalog.md
+++ b/plugins/java-reviewer/skills/java-reviewer/references/refactoring-catalog.md
@@ -1,0 +1,240 @@
+# Refactoring Catalog (Refactoring + Design Patterns Applied)
+
+## Table of Contents
+1. Refactoring Principles
+2. Code Smells → Refactoring Mapping
+3. Key Refactoring Techniques (Java Examples)
+4. Large-Scale Refactoring Strategies
+
+---
+
+## 1. Refactoring Principles
+
+Refactoring is **improving the internal structure of code without changing its external behavior**.
+
+### When to Refactor
+- **Rule of Three**: Refactor when you do something similar for the third time
+- **Before adding a feature**: Clean up the structure first so the new feature fits in easily
+- **During code review**: When you detect smells while reading code
+- **When fixing bugs**: Tidy up as you work to understand the code
+
+### When NOT to Refactor
+- If there are no tests, write tests first
+- If the code is too broken to salvage, consider a rewrite
+- If a deadline is imminent, record the tech debt and move on
+
+### Safe Refactoring Procedure
+1. Verify all tests pass before making changes
+2. Make changes in small increments (one refactoring at a time)
+3. Run tests after each change
+4. Revert immediately on failure
+5. Commit on success and move to the next step
+
+---
+
+## 2. Code Smells → Refactoring Mapping
+
+### Unnecessary Complexity
+
+| Smell | Description | Response |
+|-------|-------------|----------|
+| Dead Code | Unused variables, methods, classes | Delete (history lives in VCS) |
+| Speculative Generality | "Might need it someday" | Remove / Inline (YAGNI) |
+| Duplicated Code | Same code in multiple places | Extract Method → unify |
+| Magic Number | Meaningless literal values | Replace Magic Number with Constant |
+
+### Structural Issues
+
+| Smell | Description | Response |
+|-------|-------------|----------|
+| Long Method | Method doing too much | Extract Method |
+| Large Class | Class with too many responsibilities | Extract Class / Extract Subclass |
+| Long Parameter List | More than 3 parameters | Introduce Parameter Object |
+| Data Clumps | Groups of data that travel together | Extract Class |
+| Primitive Obsession | Using String/int for domain concepts | Replace Primitive with Object |
+
+### Change Resistance
+
+| Smell | Description | Response |
+|-------|-------------|----------|
+| Shotgun Surgery | One change ripples across many classes | Move Method, Move Field → cohere |
+| Divergent Change | One class changes for multiple reasons | Extract Class (apply SRP) |
+| Feature Envy | Method overuses another class's data | Move Method |
+| Inappropriate Intimacy | Excessive cross-referencing between classes | Move Method/Field, Extract Class |
+
+### Conditional Logic
+
+| Smell | Description | Response |
+|-------|-------------|----------|
+| Repeated Switch Statements | Same switch in multiple places | Replace Conditional with Polymorphism |
+| Type Code | int/String to distinguish types | Replace Type Code with Subclass/Strategy |
+| Repeated Null Checks | `if (obj != null)` everywhere | Introduce Null Object / Optional |
+
+---
+
+## 3. Key Refactoring Techniques (Java Examples)
+
+### Extract Method
+The most frequently used refactoring. Give a name to a code fragment.
+
+```java
+// Before
+public void printOwing() {
+    // Print banner
+    System.out.println("**************************");
+    System.out.println("***** Customer Owes ******");
+    System.out.println("**************************");
+
+    // Calculate outstanding amount
+    double outstanding = 0.0;
+    for (Order order : orders) {
+        outstanding += order.getAmount();
+    }
+
+    // Print details
+    System.out.println("name: " + name);
+    System.out.println("amount: " + outstanding);
+}
+
+// After
+public void printOwing() {
+    printBanner();
+    double outstanding = calculateOutstanding();
+    printDetails(outstanding);
+}
+
+private void printBanner() { /* ... */ }
+private double calculateOutstanding() { /* ... */ }
+private void printDetails(double outstanding) { /* ... */ }
+```
+
+### Replace Conditional with Polymorphism
+Replace type-based branching with polymorphism.
+
+```java
+// Before: switch smell
+public double calculatePay(Employee employee) {
+    switch (employee.getType()) {
+        case COMMISSIONED:
+            return calculateCommissionedPay(employee);
+        case HOURLY:
+            return calculateHourlyPay(employee);
+        case SALARIED:
+            return calculateSalariedPay(employee);
+        default:
+            throw new InvalidEmployeeType(employee.getType());
+    }
+}
+
+// After: polymorphism
+public abstract class Employee {
+    public abstract Money calculatePay();
+}
+
+public class CommissionedEmployee extends Employee {
+    @Override
+    public Money calculatePay() {
+        return basePay.add(commission.multiply(salesAmount));
+    }
+}
+
+public class HourlyEmployee extends Employee {
+    @Override
+    public Money calculatePay() {
+        return hourlyRate.multiply(hoursWorked);
+    }
+}
+```
+
+### Introduce Parameter Object
+Bundle repeating parameter groups into an object.
+
+```java
+// Before
+public List<Transaction> findTransactions(
+    LocalDate startDate, LocalDate endDate,
+    BigDecimal minAmount, BigDecimal maxAmount) { ... }
+
+// After
+public record TransactionFilter(
+    LocalDate startDate, LocalDate endDate,
+    BigDecimal minAmount, BigDecimal maxAmount
+) {
+    public boolean matches(Transaction tx) {
+        return !tx.date().isBefore(startDate)
+            && !tx.date().isAfter(endDate)
+            && tx.amount().compareTo(minAmount) >= 0
+            && tx.amount().compareTo(maxAmount) <= 0;
+    }
+}
+
+public List<Transaction> findTransactions(TransactionFilter filter) {
+    return transactions.stream()
+        .filter(filter::matches)
+        .collect(Collectors.toList());
+}
+```
+
+### Replace Primitive with Domain Object
+Promote primitives to domain objects.
+
+```java
+// Before: String representing an email
+public void sendEmail(String email, String subject) { ... }
+// "not-an-email" can slip in
+
+// After: Type safety via domain object
+public record Email(String value) {
+    public Email {
+        if (!value.matches("^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$")) {
+            throw new IllegalArgumentException("Invalid email: " + value);
+        }
+    }
+}
+
+public void sendEmail(Email to, String subject) { ... }
+```
+
+### Extract Interface
+Separate the contract from the implementation.
+
+```java
+// Extract interface from implementation-dependent code
+public interface NotificationSender {
+    void send(Notification notification);
+}
+
+public class EmailNotificationSender implements NotificationSender { ... }
+public class SmsNotificationSender implements NotificationSender { ... }
+public class SlackNotificationSender implements NotificationSender { ... }
+```
+
+---
+
+## 4. Large-Scale Refactoring Strategies
+
+### Strangler Fig Pattern
+Gradually replace a legacy system.
+
+1. Build new code alongside the existing system
+2. Incrementally redirect traffic/calls to the new code
+3. Remove the old code piece by piece
+4. Repeat until fully replaced
+
+### Branch by Abstraction
+Use when replacing large-scale dependencies.
+
+1. Create an abstraction layer (interface) over the replacement target
+2. Change existing code to access through the abstraction
+3. Build a new implementation behind the abstraction
+4. Remove the old implementation
+
+### Micro-Refactoring Habits
+Continuously perform small refactorings as part of daily work:
+- Rename a variable to a better name (immediately)
+- Extract one paragraph from a long method (10 minutes)
+- Extract a common method when duplication is found (15 minutes)
+- Remove unnecessary comments and clarify the code (5 minutes)
+
+The accumulation of these small improvements is the key to maintaining code quality.
+Boy Scout Rule: "Leave the campground cleaner than you found it."

--- a/plugins/java-reviewer/skills/java-reviewer/references/release-it-stability.md
+++ b/plugins/java-reviewer/skills/java-reviewer/references/release-it-stability.md
@@ -1,0 +1,494 @@
+# Release It! — Stability and Production Patterns
+
+Based on *Release It! Design and Deploy Production-Ready Software* (2nd edition) by Michael T. Nygard.
+Adapted for Java 25 + Spring Boot 4 + Virtual Threads.
+
+## Table of Contents
+1. Stability Patterns
+2. Stability Anti-Patterns
+3. Capacity Patterns
+4. Operational Transparency
+5. Application Guidelines
+
+---
+
+## 1. Stability Patterns
+
+### Timeout
+
+Every integration point must have a timeout. Systems that wait indefinitely will eventually exhaust their thread pool (or in Virtual Thread terms, pile up pending work until memory is exhausted).
+
+**The rule**: No network call without a timeout. This includes:
+- HTTP client calls (external APIs, webhooks)
+- JDBC connections and queries
+- Redis operations
+- SMTP sending
+
+```java
+// HTTP client with timeouts (Spring WebClient)
+@Bean
+public WebClient externalWebClient() {
+  var httpClient = HttpClient.create()
+      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3_000)
+      .responseTimeout(Duration.ofSeconds(5))
+      .doOnConnected(conn ->
+          conn.addHandlerLast(new ReadTimeoutHandler(5))
+              .addHandlerLast(new WriteTimeoutHandler(5)));
+  return WebClient.builder()
+      .clientConnector(new ReactorClientHttpConnector(httpClient))
+      .build();
+}
+
+// JDBC timeout (application.yaml)
+spring:
+  datasource:
+    hikari:
+      connection-timeout: 3000      # ms to get a connection from pool
+      validation-timeout: 1000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+  jpa:
+    properties:
+      jakarta.persistence.query.timeout: 5000   # query-level timeout
+```
+
+```yaml
+# Redis timeout (application.yaml)
+spring:
+  data:
+    redis:
+      timeout: 2000ms          # command timeout
+      connect-timeout: 1000ms
+      lettuce:
+        pool:
+          max-active: 20
+          max-wait: 500ms      # pool acquisition timeout
+```
+
+**Timeout values by operation type**:
+
+| Operation | Connect Timeout | Read/Query Timeout |
+|-----------|----------------|-------------------|
+| HTTP external call | 3s | 5s |
+| Database query | 3s | 5s |
+| Redis command | 1s | 2s |
+| SMTP send | 3s | 10s |
+
+### Circuit Breaker
+
+Prevent repeated calls to a failing service. After a threshold of failures, open the circuit and fail fast. After a recovery window, allow a probe request.
+
+States: **Closed** (normal) → **Open** (failing fast) → **Half-Open** (probing)
+
+```java
+// Using Resilience4j (add to libs.versions.toml)
+@Bean
+public CircuitBreaker externalServiceCircuitBreaker(CircuitBreakerRegistry registry) {
+  var config = CircuitBreakerConfig.custom()
+      .failureRateThreshold(50)                    // open at 50% failure rate
+      .waitDurationInOpenState(Duration.ofSeconds(30))
+      .permittedNumberOfCallsInHalfOpenState(3)
+      .slidingWindowSize(10)
+      .build();
+  return registry.circuitBreaker("external-service", config);
+}
+
+// Apply to external call
+@Service
+public class PushNotificationService {
+  private final CircuitBreaker circuitBreaker;
+
+  public void send(PushNotification notification) {
+    circuitBreaker.executeRunnable(() -> pushClient.send(notification));
+  }
+}
+```
+
+**Where to apply Circuit Breakers**:
+- Push notification service
+- Email/SMTP sending
+- External webhook delivery
+- Third-party APIs (payment, lookup, etc.)
+
+### Bulkhead
+
+Isolate failures to a partition. If one part fails, it doesn't sink the whole ship.
+
+**Thread pool bulkhead**: Give different work types their own bounded executor.
+
+```java
+// CPU-bound tasks (e.g., PDF generation, heavy transformations) get their own pool
+@Bean("cpuBoundExecutor")
+public Executor cpuBoundExecutor() {
+  return new ThreadPoolExecutor(
+      Runtime.getRuntime().availableProcessors(),
+      Runtime.getRuntime().availableProcessors(),
+      60L, TimeUnit.SECONDS,
+      new LinkedBlockingQueue<>(100),              // bounded queue — reject, don't pile up
+      new ThreadPoolExecutor.CallerRunsPolicy()    // backpressure
+  );
+}
+
+// Virtual Thread executor for I/O-bound (default for Spring Boot 4)
+// Don't create another Virtual Thread pool — the platform default is fine
+
+// Usage
+@Async("cpuBoundExecutor")
+public CompletableFuture<ReportData> generateReport(UUID tenantId) { ... }
+```
+
+**Semaphore bulkhead**: Limit concurrent access to a shared resource.
+
+```java
+// Limit concurrent webhook deliveries
+private final Semaphore webhookSemaphore = new Semaphore(50);
+
+public void deliverWebhook(Webhook webhook) {
+  if (!webhookSemaphore.tryAcquire(1, TimeUnit.SECONDS)) {
+    throw new WebhookCapacityExceededException("Webhook delivery queue full");
+  }
+  try {
+    doDeliver(webhook);
+  } finally {
+    webhookSemaphore.release();
+  }
+}
+```
+
+### Fail Fast
+
+Validate and reject bad requests at the earliest possible point. Don't let invalid input propagate deep into the system.
+
+```java
+// At filter/interceptor level: validate tenant/context before hitting service
+@Component
+public class TenantValidationFilter extends OncePerRequestFilter {
+  @Override
+  protected void doFilterInternal(HttpServletRequest req, ...) {
+    var tenantId = extractTenantId(req);
+    if (!tenantRepository.existsById(tenantId)) {
+      sendProblemDetail(response, HttpStatus.NOT_FOUND, "Tenant not found");
+      return;
+    }
+    filterChain.doFilter(req, response);
+  }
+}
+
+// At service level: validate required headers before doing expensive work
+public OrderResponse placeOrder(PlaceOrderCommand command) {
+  // Validate required fields present at boundary before loading aggregates
+  Objects.requireNonNull(command.customerId(), "customerId required");
+
+  // Validate resource accessible before loading data
+  if (!orderRepository.existsByIdAndCustomerId(
+        command.orderId(), command.customerId())) {
+    throw new OrderNotFoundException(command.orderId());
+  }
+  // ... proceed with expensive operations
+}
+```
+
+### Retry with Backoff
+
+Retry transient failures, but only on idempotent operations. Use exponential backoff with jitter.
+
+```java
+// Retry configuration (Resilience4j)
+@Bean
+public Retry smtpRetry(RetryRegistry registry) {
+  var config = RetryConfig.custom()
+      .maxAttempts(3)
+      .waitDuration(Duration.ofMillis(500))
+      .intervalFunction(IntervalFunction.ofExponentialRandomBackoff(500, 2.0, 0.5))
+      .retryExceptions(MailException.class, ConnectException.class)
+      .ignoreExceptions(InvalidAddressException.class)  // don't retry on bad input
+      .build();
+  return registry.retry("smtp", config);
+}
+```
+
+**Retry decision table**:
+
+| Operation | Retryable? | Reason |
+|-----------|-----------|--------|
+| GET requests | Yes | Idempotent |
+| PUT requests | Yes | Idempotent by design |
+| POST with idempotency key | Yes | Key ensures exactly-once |
+| POST without idempotency | No | Risk of duplicate creation |
+| DELETE | Yes (usually) | Idempotent |
+| DB reads | Yes | No side effects |
+| DB writes | With idempotency only | Risk of duplicate |
+
+### Handshaking
+
+Let callers and callees negotiate load. Use backpressure signals.
+
+```java
+// Return 429 when overloaded (not 500)
+@ExceptionHandler(RateLimitExceededException.class)
+public ResponseEntity<ProblemDetail> handleRateLimit(RateLimitExceededException ex) {
+  var pd = ProblemDetail.forStatus(HttpStatus.TOO_MANY_REQUESTS);
+  pd.setDetail("Rate limit exceeded");
+  return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+      .header("Retry-After", "60")
+      .body(pd);
+}
+```
+
+---
+
+## 2. Stability Anti-Patterns
+
+### Cascading Failures
+
+One component failure triggers failures in dependent components.
+
+**Symptom**: A slow DB query causes the HTTP thread pool to exhaust, causing all requests to fail, even those that don't need the DB.
+
+**Prevention**:
+- Bulkhead: isolate DB-dependent and DB-independent request handlers
+- Circuit Breaker: stop calling a failing dependency
+- Timeouts: bounded waiting prevents indefinite blocking
+
+### Blocked Threads
+
+In Virtual Thread context this is less severe but still dangerous with CPU-bound work.
+
+```java
+// Bad: CPU-bound work on Virtual Thread pool
+@GetMapping("/reports")
+public ReportData generateReport() {
+  return expensiveCpuWork();  // blocks a Virtual Thread for minutes
+}
+
+// Good: off-load to bounded executor
+@GetMapping("/reports")
+public CompletableFuture<ReportData> generateReport() {
+  return CompletableFuture.supplyAsync(this::expensiveCpuWork, cpuBoundExecutor);
+}
+```
+
+For Virtual Threads specifically: **never use `synchronized`** — it pins the carrier thread.
+
+### Unbalanced Capacities
+
+Upstream component produces faster than downstream can consume.
+
+**Detection**: Message queues growing, `Retry-After` headers appearing, 503 responses from downstream.
+
+**Prevention**:
+- Queue with bounded capacity + `CallerRunsPolicy` (backpressure)
+- Rate limiting at ingress (webhook receiver)
+- Async processing with dead-letter queue for failures
+
+```java
+// Webhook receiver: accept fast, process asynchronously
+@PostMapping("/webhooks/events")
+@ResponseStatus(HttpStatus.ACCEPTED)  // 202, not 200
+public void receiveWebhook(@RequestBody WebhookPayload payload) {
+  webhookQueue.offer(payload);  // fast, non-blocking
+}
+```
+
+### Slow Responses
+
+Worse than fast failures because they hold resources for longer.
+
+**Prevention**: Always set read timeouts. Return `503 Service Unavailable` with `Retry-After` instead of a slow 200.
+
+### Unbounded Result Sets
+
+DB queries without limits that return thousands of rows.
+
+```java
+// Bad: no limit
+List<Order> allOrders = orderRepository.findByCustomerId(customerId);
+
+// Good: cursor pagination with limit
+List<Order> orders = orderRepository
+    .findByCustomerIdAndIdLessThan(customerId, cursor, PageRequest.of(0, 50));
+```
+
+### Integration Point Failures
+
+Every call to an external service (DB, cache, SMTP, push notification, webhooks) is a potential failure point.
+
+**Mitigation checklist**:
+- [ ] Timeout configured
+- [ ] Circuit Breaker applied (for external HTTP)
+- [ ] Retry with backoff (idempotent only)
+- [ ] Fallback behavior defined (degrade gracefully)
+- [ ] Error logged with context (tenantId, requestId)
+
+---
+
+## 3. Capacity Patterns
+
+### Connection Pool Sizing
+
+Formula: `pool size = (core count * 2) + effective_spindle_count`
+
+For I/O-bound apps with Virtual Threads:
+
+```yaml
+# Recommended starting point for 4-core instance
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 20     # adjust based on load testing
+      minimum-idle: 5
+```
+
+Virtual Threads do NOT mean "unlimited connections". DB has finite connection slots. A large Virtual Thread count hitting a small connection pool creates contention on pool acquisition.
+
+### Steady State
+
+Systems must return to steady state after disturbances. Watch for:
+- Memory that never releases → heap profiling, check for reference leaks
+- Connection pools that drain → circuit break + timeout on acquisition
+- Log files that grow without rotation → logback `RollingFileAppender`
+
+---
+
+## 4. Operational Transparency
+
+### Health Checks
+
+```java
+// Spring Actuator — expose /actuator/health
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
+  endpoint:
+    health:
+      show-details: when-authorized
+
+// Custom health indicator
+@Component
+public class RedisHealthIndicator extends AbstractHealthIndicator {
+  private final RedisConnectionFactory connectionFactory;
+
+  @Override
+  protected void doHealthCheck(Health.Builder builder) {
+    try (var conn = connectionFactory.getConnection()) {
+      conn.ping();
+      builder.up();
+    } catch (Exception e) {
+      builder.down().withException(e);
+    }
+  }
+}
+```
+
+### Structured Logging for Observability
+
+```java
+// Log with correlation IDs and context
+@Slf4j
+@Service
+public class OrderService {
+  public void processOrder(UUID tenantId, UUID orderId, String requestId) {
+    log.info("Processing order: tenantId={}, orderId={}, requestId={}",
+        tenantId, orderId, requestId);
+
+    // On failure
+    log.error("Order processing failed: tenantId={}, orderId={}, requestId={}, error={}",
+        tenantId, orderId, requestId, ex.getMessage(), ex);
+  }
+}
+```
+
+**Fields to always log**:
+- `tenantId` / context identifier — for multi-tenant debugging
+- `requestId` / `traceId` — for request tracing
+- Operation outcome: `success`, `failure`, `partial`
+- Duration for slow-path detection
+
+### Metrics
+
+Expose metrics via Micrometer (Spring Boot default):
+
+```java
+@Component
+public class OrderMetrics {
+  private final Counter ordersPlacedCounter;
+  private final Timer orderProcessingTimer;
+
+  public OrderMetrics(MeterRegistry registry) {
+    this.ordersPlacedCounter = Counter.builder("app.orders.placed")
+        .tag("channel", "web")
+        .register(registry);
+    this.orderProcessingTimer = Timer.builder("app.orders.processing.duration")
+        .register(registry);
+  }
+
+  public void recordPlaced() { ordersPlacedCounter.increment(); }
+  public <T> T recordProcessing(Supplier<T> operation) {
+    return orderProcessingTimer.record(operation);
+  }
+}
+```
+
+---
+
+## 5. Application Guidelines
+
+### External Dependency Map
+
+| Dependency | Failure Mode | Mitigation |
+|-----------|-------------|------------|
+| Database | Slow queries, connection exhaustion | Timeout + connection pool + query timeout |
+| Cache (Redis, etc.) | Network partition, OOM eviction | Timeout + Circuit Breaker + graceful degradation |
+| SMTP | Server down, rate limit | Circuit Breaker + Retry + async send |
+| Push notification | Quota exceeded, auth failure | Circuit Breaker + dead-letter queue |
+| External HTTP APIs | Timeout, 5xx, auth failure | Retry + idempotency key |
+
+### Virtual Thread Specific Rules
+
+```java
+// FORBIDDEN: synchronized pins Virtual Thread carrier thread
+public synchronized void criticalSection() { jdbcCall(); }
+
+// REQUIRED: ReentrantLock allows Virtual Thread to park without pinning
+private final ReentrantLock lock = new ReentrantLock();
+
+public void criticalSection() {
+  lock.lock();
+  try {
+    jdbcCall();  // Virtual Thread parks here, carrier thread is free
+  } finally {
+    lock.unlock();
+  }
+}
+
+// FORBIDDEN: ThreadLocal state leaks across Virtual Thread reuse
+private static final ThreadLocal<RequestContext> CTX = new ThreadLocal<>();
+
+// REQUIRED: ScopedValue has bounded lifetime
+private static final ScopedValue<RequestContext> CTX = ScopedValue.newInstance();
+```
+
+### Validate at the Boundary
+
+Validate tenant context, required headers, and input constraints at the earliest entry point (filter, interceptor, or controller) — not deep in the service layer. Fail Fast prevents wasted work and makes error sources clear.
+
+```java
+// Fail Fast: reject early at controller boundary
+@PostMapping("/orders")
+public ResponseEntity<OrderResponse> placeOrder(
+    @RequestHeader("X-Tenant-Id") UUID tenantId,   // 400 if missing
+    @PathVariable UUID customerId,
+    @RequestBody @Valid PlaceOrderRequest request) {
+  // tenantId and input are validated before reaching the service
+}
+```
+
+---
+
+## Cross-References
+
+- For Application Service where these patterns are implemented → `domain-driven-design.md`
+- For Java concurrency idioms (ReentrantLock, ScopedValue) → `effective-java.md`
+- For Spring Boot 4 health/actuator configuration → `spring-boot4-conventions.md`

--- a/plugins/java-tester/.claude-plugin/plugin.json
+++ b/plugins/java-tester/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "java-tester",
+  "version": "0.0.1",
+  "description": "Java TDD workflow and test writing — Red-Green-Refactor, test type strategy, Mockito, Testcontainers, legacy code testing",
+  "author": {
+    "name": "ppzxc",
+    "email": "cjh8487@naver.com",
+    "url": "https://ppzxc.github.io"
+  }
+}

--- a/plugins/java-tester/README.ko.md
+++ b/plugins/java-tester/README.ko.md
@@ -1,0 +1,29 @@
+# java-tester
+
+Java TDD 워크플로우 및 테스트 작성 스킬입니다.
+
+## 포함 내용
+
+1. **TDD 워크플로우** — Red-Green-Refactor 사이클
+2. **테스트 유형 전략** — No-Docker/Slice (~70%), Integration (~25%), E2E (~5%)
+3. **커버리지 체크리스트** — Controller, Service, Repository 테스트 요구사항
+4. **테스트 네이밍** — `methodName_scenario_expectedBehavior` 컨벤션
+5. **테스트 더블** — `@Mock` vs `@MockBean` 사용 규칙
+6. **레거시 코드 테스트** — 심(Seam), 특성화 테스트, 추출 및 격리
+
+## 설치
+
+```bash
+/plugin marketplace add ppzxc/java-plugins
+/plugin install java-tester
+```
+
+## 사용 방법
+
+설치 후 Claude Code에서 슬래시 커맨드로 스킬을 호출합니다:
+
+```
+/java-tester
+```
+
+TDD 적용, `*Test.java` 또는 `*IT.java` 파일 작성, 테스트 전략 결정 시 자동으로 활성화됩니다.

--- a/plugins/java-tester/README.md
+++ b/plugins/java-tester/README.md
@@ -1,0 +1,29 @@
+# java-tester
+
+A Java TDD workflow and test writing skill for Claude Code.
+
+## Contents
+
+1. **TDD Workflow** — Red-Green-Refactor cycle
+2. **Test Type Strategy** — No-Docker/Slice (~70%), Integration (~25%), E2E (~5%)
+3. **Coverage Checklist** — Controller, Service, Repository test requirements
+4. **Test Naming** — `methodName_scenario_expectedBehavior` convention
+5. **Test Doubles** — `@Mock` vs `@MockBean` usage rules
+6. **Legacy Code Testing** — Seams, characterization tests, extract and isolate
+
+## Installation
+
+```bash
+/plugin marketplace add ppzxc/java-plugins
+/plugin install java-tester
+```
+
+## Usage
+
+Invoke as a slash command in Claude Code:
+
+```
+/java-tester
+```
+
+Also activates automatically when applying TDD, writing `*Test.java` or `*IT.java` files, or making test strategy decisions.

--- a/plugins/java-tester/skills/java-tester/SKILL.md
+++ b/plugins/java-tester/skills/java-tester/SKILL.md
@@ -6,6 +6,7 @@ description: >
   *Test.java or *IT.java file creation or modification,
   test strategy decisions, or coverage analysis.
   NOT for writing production code (java-coder handles that).
+user_invocable: true
 ---
 
 # Java Tester
@@ -22,7 +23,7 @@ TDD workflow and test writing guide for Java 25 + Spring Boot 4.
 
 Repeat per behavior unit. Commit after each green phase.
 
-→ See `../java-coder/references/tdd-and-legacy.md` for deep-dive on test strategy and legacy code techniques
+→ See `references/tdd-and-legacy.md` for deep-dive on test strategy and legacy code techniques
 
 ---
 
@@ -105,7 +106,7 @@ When adding tests to untested production code:
 3. **Extract and isolate** — use Extract Method to create a testable unit
 4. **Then fix** — change behavior under test coverage
 
-→ See `../java-coder/references/tdd-and-legacy.md` for seam types and techniques
+→ See `references/tdd-and-legacy.md` for seam types and techniques
 
 ---
 
@@ -113,5 +114,5 @@ When adding tests to untested production code:
 
 | File | When to Open |
 |------|-------------|
-| `../java-coder/references/tdd-and-legacy.md` | TDD deep-dive, legacy code seams, test doubles |
+| `references/tdd-and-legacy.md` | TDD deep-dive, legacy code seams, test doubles |
 | **spring** skill | Spring test annotations, @WebMvcTest, @DataJpaTest, @SpringBootTest patterns |

--- a/plugins/java-tester/skills/java-tester/references/tdd-and-legacy.md
+++ b/plugins/java-tester/skills/java-tester/references/tdd-and-legacy.md
@@ -1,0 +1,381 @@
+# Testing Strategies and Legacy Code (TDD + Working Effectively with Legacy Code)
+
+## Table of Contents
+1. TDD Core Cycle
+2. Test Writing Principles
+3. Java Testing Patterns
+4. Dealing with Legacy Code
+5. Test Doubles (Mock, Stub, Fake)
+6. Making Untestable Code Testable
+
+---
+
+## 1. TDD Core Cycle
+
+### Red → Green → Refactor
+
+```
+[Red]      Write a failing test
+  ↓
+[Green]    Write the minimum code to pass the test
+  ↓
+[Refactor] Remove duplication and improve structure
+  ↓
+(Repeat)
+```
+
+### The Three Laws of TDD
+1. Do not write production code until you have a failing unit test
+2. Write only enough of a unit test to fail (compilation failure counts)
+3. Write only enough production code to pass the currently failing test
+
+### TDD Rhythm
+- Each cycle should complete within 1–5 minutes
+- If a cycle takes longer, break the step into smaller pieces
+- In the Green phase, write "minimum code" — it doesn't need to be clean yet
+- In the Refactor phase, make it clean
+
+---
+
+## 2. Test Writing Principles
+
+### F.I.R.S.T Principles
+- **Fast**: Execute in milliseconds. Slow tests won't get run
+- **Independent**: No order dependency between tests. Runnable in any order
+- **Repeatable**: Same result in any environment. No network/DB dependencies
+- **Self-Validating**: Automatically determines pass/fail. Manually scanning logs is not testing
+- **Timely**: Written just before production code (TDD) or immediately after
+
+### One Concept Per Test
+Do not verify multiple concepts in a single test method.
+
+```java
+// Bad: Multiple concepts in one test
+@Test
+void testOrder() {
+    Order order = new Order();
+    order.addItem(new Item("A", 1000));
+    assertEquals(1, order.getItemCount());     // item addition
+    assertEquals(1000, order.getTotal());       // total calculation
+    order.applyDiscount(10);
+    assertEquals(900, order.getTotal());        // discount application
+}
+
+// Good: Separated by concept
+@Test
+void addItem_increasesItemCount() {
+    order.addItem(new Item("A", 1000));
+    assertThat(order.getItemCount()).isEqualTo(1);
+}
+
+@Test
+void getTotal_returnsSumOfItemPrices() {
+    order.addItem(new Item("A", 1000));
+    order.addItem(new Item("B", 2000));
+    assertThat(order.getTotal()).isEqualTo(3000);
+}
+
+@Test
+void applyDiscount_reducesTotalByPercentage() {
+    order.addItem(new Item("A", 1000));
+    order.applyDiscount(10);
+    assertThat(order.getTotal()).isEqualTo(900);
+}
+```
+
+### Given-When-Then Structure
+Clearly divide test code into three phases.
+
+```java
+@Test
+void withdraw_withSufficientBalance_reducesBalance() {
+    // Given: An account with a balance of 10,000
+    BankAccount account = new BankAccount(Money.of(10_000));
+
+    // When: Withdraw 3,000
+    account.withdraw(Money.of(3_000));
+
+    // Then: Balance is 7,000
+    assertThat(account.getBalance()).isEqualTo(Money.of(7_000));
+}
+
+@Test
+void withdraw_withInsufficientBalance_throwsException() {
+    // Given
+    BankAccount account = new BankAccount(Money.of(1_000));
+
+    // When & Then
+    assertThatThrownBy(() -> account.withdraw(Money.of(5_000)))
+        .isInstanceOf(InsufficientFundsException.class)
+        .hasMessageContaining("Insufficient funds");
+}
+```
+
+### Test Naming Convention
+The method name alone should tell you what is being tested.
+Pattern: `methodUnderTest_condition_expectedResult`
+
+```java
+void calculateShipping_forOverseasOrder_addsInternationalFee()
+void login_withExpiredToken_returnsUnauthorized()
+void findUsers_withNoMatch_returnsEmptyList()
+```
+
+---
+
+## 3. Java Testing Patterns
+
+### Test Fixture Management
+```java
+class OrderServiceTest {
+    private OrderService orderService;
+    private OrderRepository mockRepository;
+    private NotificationSender mockNotifier;
+
+    @BeforeEach
+    void setUp() {
+        mockRepository = mock(OrderRepository.class);
+        mockNotifier = mock(NotificationSender.class);
+        orderService = new OrderService(mockRepository, mockNotifier);
+    }
+}
+```
+
+### Boundary Value Testing
+Boundary conditions are where bugs hide.
+
+```java
+// If the age restriction is 18 and above
+@ParameterizedTest
+@ValueSource(ints = {17, 18, 19})
+void ageRestriction_boundaryValues(int age) {
+    User user = new User(age);
+    if (age < 18) {
+        assertThat(user.canPurchaseAlcohol()).isFalse();
+    } else {
+        assertThat(user.canPurchaseAlcohol()).isTrue();
+    }
+}
+```
+
+### Exception Testing
+```java
+@Test
+void createUser_withBlankName_throwsValidationException() {
+    assertThatThrownBy(() -> new User("", "test@mail.com"))
+        .isInstanceOf(ValidationException.class)
+        .hasFieldOrPropertyWithValue("field", "name");
+}
+```
+
+---
+
+## 4. Dealing with Legacy Code
+
+Definition of legacy code: **code without tests** (Michael Feathers)
+
+### The Legacy Code Change Algorithm
+1. **Identify the change point**
+2. **Find a test point**
+3. **Break dependencies** (to make it testable)
+4. **Write tests**
+5. **Make changes and refactor**
+
+### Key Dependency-Breaking Techniques
+
+#### Extract and Override (The Safest Starting Point)
+Extract hard-to-test dependencies into a method, then override in tests.
+
+```java
+// Legacy code: Directly accesses the DB
+public class ReportGenerator {
+    public Report generate() {
+        // Direct DB access (untestable)
+        Connection conn = DriverManager.getConnection(DB_URL);
+        List<Record> records = queryRecords(conn);
+        return buildReport(records);
+    }
+}
+
+// Step 1: Extract the dependency into a method
+public class ReportGenerator {
+    public Report generate() {
+        List<Record> records = fetchRecords();  // Extracted!
+        return buildReport(records);
+    }
+
+    protected List<Record> fetchRecords() {  // Changed to protected
+        Connection conn = DriverManager.getConnection(DB_URL);
+        return queryRecords(conn);
+    }
+}
+
+// Step 2: Override in tests
+class TestableReportGenerator extends ReportGenerator {
+    private final List<Record> testRecords;
+
+    TestableReportGenerator(List<Record> testRecords) {
+        this.testRecords = testRecords;
+    }
+
+    @Override
+    protected List<Record> fetchRecords() {
+        return testRecords;  // Return test data
+    }
+}
+
+// Step 3: Write the test
+@Test
+void generate_withRecords_producesCorrectReport() {
+    var records = List.of(new Record("A", 100), new Record("B", 200));
+    var generator = new TestableReportGenerator(records);
+
+    Report report = generator.generate();
+
+    assertThat(report.getTotalAmount()).isEqualTo(300);
+}
+```
+
+#### Introduce Interface (Better Long-Term Approach)
+Change from depending on concrete classes to depending on interfaces.
+
+```java
+// Extract interface
+public interface RecordFetcher {
+    List<Record> fetch();
+}
+
+// Production implementation
+public class DatabaseRecordFetcher implements RecordFetcher {
+    public List<Record> fetch() {
+        // Actual DB access
+    }
+}
+
+// Switch to constructor injection
+public class ReportGenerator {
+    private final RecordFetcher fetcher;
+
+    public ReportGenerator(RecordFetcher fetcher) {
+        this.fetcher = fetcher;
+    }
+
+    public Report generate() {
+        return buildReport(fetcher.fetch());
+    }
+}
+```
+
+#### Characterization Test
+A test that records the current behavior of the code. Used to build a safety net before refactoring.
+
+```java
+// "I don't know what this code does" → Write a characterization test
+@Test
+void characterize_calculateDiscount_currentBehavior() {
+    // Record current behavior as-is
+    LegacyPricingEngine engine = new LegacyPricingEngine();
+
+    // Record current outputs for various inputs
+    assertThat(engine.calculateDiscount(100, "VIP")).isEqualTo(15.0);
+    assertThat(engine.calculateDiscount(100, "NORMAL")).isEqualTo(5.0);
+    assertThat(engine.calculateDiscount(0, "VIP")).isEqualTo(0.0);
+    assertThat(engine.calculateDiscount(-10, "VIP")).isEqualTo(0.0);  // Verify negative handling
+}
+```
+
+---
+
+## 5. Test Doubles (Mock, Stub, Fake)
+
+### Terminology
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| **Stub** | Returns predetermined values | `when(repo.findById(1L)).thenReturn(user)` |
+| **Mock** | Verifies interactions occurred | `verify(notifier).send(any())` |
+| **Fake** | A working simplified implementation | `InMemoryRepository` |
+| **Spy** | Wraps a real object, overriding only parts | `spy(realService)` |
+
+### Usage Principles
+- **Prefer state verification** (check result values). Use mock verification (behavior verification) only for side effects
+- Too many mocks signal a design problem: too many dependencies
+- Don't mock types you don't own: create an Adapter for external libraries and mock the Adapter
+
+```java
+// State verification (preferred)
+@Test
+void processOrder_calculatesTotalCorrectly() {
+    Order order = orderService.process(items);
+    assertThat(order.getTotal()).isEqualTo(Money.of(15_000));
+}
+
+// Behavior verification (for side effect confirmation)
+@Test
+void processOrder_sendsConfirmationEmail() {
+    orderService.process(items);
+    verify(emailSender).send(argThat(email ->
+        email.getSubject().contains("Order Confirmation")
+    ));
+}
+```
+
+---
+
+## 6. Making Untestable Code Testable
+
+### Common Untestable Patterns and Solutions
+
+| Problem | Solution |
+|---------|----------|
+| Static method calls | Wrap in a class/interface |
+| Direct `new` instantiation | Constructor injection or Factory injection |
+| Global state (Singleton) | Extract interface + DI |
+| Time dependency (`LocalDateTime.now()`) | Inject `Clock` |
+| File/network access | Extract interface + Fake implementation |
+
+### Solving Time Dependencies
+```java
+// Bad: Untestable (depends on current time)
+public class MembershipService {
+    public boolean isExpired(Membership m) {
+        return m.getExpiryDate().isBefore(LocalDate.now());
+    }
+}
+
+// Good: Time control via Clock injection
+public class MembershipService {
+    private final Clock clock;
+
+    public MembershipService(Clock clock) {
+        this.clock = clock;
+    }
+
+    public boolean isExpired(Membership m) {
+        return m.getExpiryDate().isBefore(LocalDate.now(clock));
+    }
+}
+
+// Test
+@Test
+void isExpired_afterExpiryDate_returnsTrue() {
+    Clock fixedClock = Clock.fixed(
+        LocalDate.of(2025, 6, 1).atStartOfDay(ZoneId.systemDefault()).toInstant(),
+        ZoneId.systemDefault()
+    );
+    var service = new MembershipService(fixedClock);
+    var membership = new Membership(LocalDate.of(2025, 5, 31));
+
+    assertThat(service.isExpired(membership)).isTrue();
+}
+```
+
+### Finding Seams
+A seam is a place where you can alter behavior without editing the code at that point.
+
+Types of seams in Java:
+1. **Object Seam**: Swap behavior via polymorphism (most common)
+2. **Compile Seam**: Inject different implementations (DI / compile config)
+3. **Link Seam**: Swap via classpath (different JAR at test time)
+
+In legacy code, find seams first, then break dependencies at those points to insert tests.

--- a/plugins/spring/.claude-plugin/plugin.json
+++ b/plugins/spring/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "spring",
+  "version": "0.0.1",
+  "description": "Spring Boot 4 conventions — constructor injection, ProblemDetail, REST patterns, test annotations, security, observability, migration",
+  "author": {
+    "name": "ppzxc",
+    "email": "cjh8487@naver.com",
+    "url": "https://ppzxc.github.io"
+  }
+}

--- a/plugins/spring/README.ko.md
+++ b/plugins/spring/README.ko.md
@@ -1,0 +1,28 @@
+# spring
+
+Spring Boot 4 컨벤션 스킬입니다.
+
+## 포함 내용
+
+1. **핵심 컨벤션** — 생성자 주입, `@RestController`, `@Transactional` 배치, ProblemDetail, API 버전 관리, Actuator
+2. **REST Controller 패턴** — 생성자 주입을 사용한 표준 컨트롤러 구조
+3. **에러 처리** — `@RestControllerAdvice`와 RFC 9457 ProblemDetail
+4. **테스트** — `@WebMvcTest`, `@DataJpaTest`, `@SpringBootTest` + Testcontainers 패턴
+5. **리뷰 체크리스트** — Spring Boot / API 품질 검사
+
+## 설치
+
+```bash
+/plugin marketplace add ppzxc/java-plugins
+/plugin install spring
+```
+
+## 사용 방법
+
+설치 후 Claude Code에서 슬래시 커맨드로 스킬을 호출합니다:
+
+```
+/spring
+```
+
+Spring Boot 4 코드 작성, 테스트, 리뷰 시 — 컨트롤러, 서비스, 리포지토리, 보안 설정, Spring 테스트 어노테이션 사용 시 자동으로 활성화됩니다.

--- a/plugins/spring/README.md
+++ b/plugins/spring/README.md
@@ -1,0 +1,28 @@
+# spring
+
+A Spring Boot 4 conventions skill for Claude Code.
+
+## Contents
+
+1. **Core Conventions** — Constructor injection, `@RestController`, `@Transactional` placement, ProblemDetail, API versioning, Actuator
+2. **REST Controller Pattern** — Standard controller structure with constructor injection
+3. **Error Handling** — RFC 9457 ProblemDetail with `@RestControllerAdvice`
+4. **Testing** — `@WebMvcTest`, `@DataJpaTest`, `@SpringBootTest` + Testcontainers patterns
+5. **Review Checklist** — Spring Boot / API quality checks
+
+## Installation
+
+```bash
+/plugin marketplace add ppzxc/java-plugins
+/plugin install spring
+```
+
+## Usage
+
+Invoke as a slash command in Claude Code:
+
+```
+/spring
+```
+
+Also activates automatically when writing, testing, or reviewing Spring Boot 4 code — controllers, services, repositories, security configuration, or Spring test annotations.

--- a/plugins/spring/skills/spring/SKILL.md
+++ b/plugins/spring/skills/spring/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Use when writing, testing, or reviewing Spring Boot 4 code — controllers, services, repositories,
   security configuration, Spring test annotations (@WebMvcTest, @DataJpaTest, @SpringBootTest),
   ProblemDetail error handling, API versioning, or any Spring Framework 7 / Jakarta EE 11 patterns.
+user_invocable: true
 ---
 
 # Spring Boot 4
@@ -20,7 +21,7 @@ Spring Boot 4 (Spring Framework 7, Jakarta EE 11) conventions for writing, testi
 - API versioning via header/URI/content negotiation — decide early and standardize
 - Health checks via Spring Actuator (`/actuator/health`)
 
-Full reference → `../java-coder/references/spring-boot4-conventions.md`
+Full reference → `references/spring-boot4-conventions.md`
 
 ---
 
@@ -193,4 +194,4 @@ class OrderIntegrationTest {
 
 | File | When to Open |
 |------|-------------|
-| `../java-coder/references/spring-boot4-conventions.md` | Full Spring Boot 4 conventions — project structure, null safety, data access, security, observability, migration notes |
+| `references/spring-boot4-conventions.md` | Full Spring Boot 4 conventions — project structure, null safety, data access, security, observability, migration notes |

--- a/plugins/spring/skills/spring/references/spring-boot4-conventions.md
+++ b/plugins/spring/skills/spring/references/spring-boot4-conventions.md
@@ -1,0 +1,556 @@
+# Spring Boot 4 Coding Conventions — Detailed Guide
+
+This document defines coding conventions for Spring Boot 4.0 (Spring Framework 7, Jakarta EE 11) environments.
+
+## Table of Contents
+1. [Platform Baseline](#platform-baseline)
+2. [Project Structure](#project-structure)
+3. [Null Safety (JSpecify)](#null-safety)
+4. [Modular Auto-Configuration](#modular-auto-configuration)
+5. [REST API Design](#rest-api-design)
+6. [API Versioning](#api-versioning)
+7. [HTTP Service Client](#http-service-client)
+8. [Configuration Management](#configuration-management)
+9. [Security (Spring Security 7)](#security)
+10. [Data Access](#data-access)
+11. [Observability](#observability)
+12. [Testing](#testing)
+13. [Error Handling](#error-handling)
+14. [Migration Notes](#migration-notes)
+
+---
+
+## Platform Baseline
+
+- **Minimum JDK**: 17 (backward compatibility)
+- **Recommended JDK**: 25 (LTS)
+- **Spring Framework**: 7.0
+- **Jakarta EE**: 11 (Servlet 6.1, JPA 3.2)
+- **Hibernate ORM**: 7.0
+- **Kotlin** (if used): 2.2+
+
+---
+
+## Project Structure
+
+### Package Layout (Feature-based vs Layer-based)
+
+**Layer-based** (small projects):
+```
+com.example.myapp/
+├── config/
+├── controller/
+├── service/
+├── repository/
+├── domain/
+├── dto/
+└── exception/
+```
+
+**Feature-based** (medium to large projects, recommended):
+```
+com.example.myapp/
+├── order/
+│   ├── OrderController.java
+│   ├── OrderService.java
+│   ├── OrderRepository.java
+│   ├── Order.java
+│   ├── CreateOrderRequest.java
+│   └── OrderResponse.java
+├── payment/
+│   ├── PaymentController.java
+│   └── ...
+├── common/
+│   ├── config/
+│   └── exception/
+└── MyAppApplication.java
+```
+
+In feature-based structure, packages represent bounded contexts. This pairs well with Spring Modulith.
+
+---
+
+## Null Safety
+
+Spring Boot 4 systematizes null safety with JSpecify annotations.
+
+### Package-Level Default Policy
+Declare `@NullMarked` in every package's `package-info.java`:
+```java
+@NullMarked
+package com.example.myapp.order;
+
+import org.jspecify.annotations.NullMarked;
+```
+This makes all types in the package @NonNull by default.
+
+### Explicit Nullable
+Only annotate `@Nullable` where null is permitted:
+```java
+import org.jspecify.annotations.Nullable;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+  @Nullable
+  Order findByOrderNumber(String orderNumber);
+}
+```
+
+### IDE Integration
+IntelliJ IDEA 2025.3+ natively supports JSpecify annotations and can detect null violations at compile time.
+
+---
+
+## Modular Auto-Configuration
+
+Spring Boot 4 splits auto-configuration into feature-specific modules. Only add the modules you need:
+
+```groovy
+// build.gradle.kts
+dependencies {
+  implementation("org.springframework.boot:spring-boot-starter-web")
+  implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+  implementation("org.springframework.boot:spring-boot-starter-validation")
+}
+```
+
+For the legacy Spring Boot 3 monolithic jar, use `spring-boot-autoconfigure-classic`, but prefer modular dependencies for new projects.
+
+---
+
+## REST API Design
+
+### Controller Conventions
+```java
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+  private final OrderService orderService;
+
+  public OrderController(OrderService orderService) {
+    this.orderService = orderService;
+  }
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public OrderResponse createOrder(@Valid @RequestBody CreateOrderRequest request) {
+    return orderService.createOrder(request);
+  }
+
+  @GetMapping("/{id}")
+  public OrderResponse getOrder(@PathVariable long id) {
+    return orderService.getOrderById(id);
+  }
+
+  @GetMapping
+  public Page<OrderResponse> listOrders(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size) {
+    return orderService.listOrders(PageRequest.of(page, size));
+  }
+
+  @DeleteMapping("/{id}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void cancelOrder(@PathVariable long id) {
+    orderService.cancelOrder(id);
+  }
+}
+```
+
+**Conventions:**
+- Declare base paths with `@RestController` + `@RequestMapping`
+- Use HTTP-method-specific annotations (`@GetMapping`, `@PostMapping`, etc.)
+- Always annotate request bodies with `@Valid`
+- Explicitly specify response status (201 Created, 204 No Content, etc.)
+- Keep controllers thin — delegate all business logic to services
+
+### DTOs (Record-based)
+```java
+public record CreateOrderRequest(
+    @NotBlank String itemCode,
+    @Positive int quantity,
+    @Nullable String couponCode
+) {}
+
+public record OrderResponse(
+    long id,
+    String orderNumber,
+    String status,
+    BigDecimal totalAmount,
+    Instant createdAt
+) {
+  public static OrderResponse from(Order order) {
+    return new OrderResponse(
+        order.getId(),
+        order.getOrderNumber(),
+        order.getStatus().name(),
+        order.getTotalAmount(),
+        order.getCreatedAt()
+    );
+  }
+}
+```
+
+---
+
+## API Versioning
+
+Spring Boot 4 provides built-in API versioning:
+
+```yaml
+# application.yml
+spring:
+  mvc:
+    apiversion:
+      type: header    # header, query-parameter, or media-type
+      header: X-API-Version
+```
+
+```java
+@RestController
+@RequestMapping("/api/products")
+public class ProductController {
+
+  @GetMapping(value = "/search", version = "1")
+  public List<ProductV1Response> searchV1(@RequestParam String query) {
+    return productService.searchV1(query);
+  }
+
+  @GetMapping(value = "/search", version = "2")
+  public Page<ProductV2Response> searchV2(
+      @RequestParam String query, Pageable pageable) {
+    return productService.searchV2(query, pageable);
+  }
+}
+```
+
+**Conventions:**
+- Decide the versioning strategy (header, query param, media type) early and standardize it
+- Provide a deprecation period before removing older versions
+- Separate DTOs per version (`ProductV1Response`, `ProductV2Response`)
+
+---
+
+## HTTP Service Client
+
+Use Spring Boot 4's declarative HTTP client. Eliminates RestTemplate / WebClient boilerplate.
+
+```java
+@HttpExchange(url = "https://payment-api.example.com")
+public interface PaymentClient {
+
+  @PostExchange("/payments")
+  PaymentResponse createPayment(@RequestBody PaymentRequest request);
+
+  @GetExchange("/payments/{paymentId}")
+  PaymentResponse getPayment(@PathVariable String paymentId);
+
+  @GetExchange("/payments")
+  List<PaymentResponse> listPayments(
+      @RequestParam("orderId") String orderId);
+}
+```
+
+Auto-configuration handles bean registration — inject directly without manual setup.
+
+---
+
+## Configuration Management
+
+### Record-based ConfigurationProperties
+```java
+@ConfigurationProperties(prefix = "app.order")
+public record OrderProperties(
+    int maxRetryCount,
+    Duration timeout,
+    @DefaultValue("100") int defaultPageSize
+) {}
+```
+
+```yaml
+# application.yml
+app:
+  order:
+    max-retry-count: 3
+    timeout: 30s
+    default-page-size: 50
+```
+
+**Conventions:**
+- Use `application.yml` as default (more readable than `.properties`)
+- Separate profile-specific config into `application-{profile}.yml`
+- Store sensitive values in environment variables or external secret managers
+- Write `@ConfigurationProperties` as records for immutability
+
+---
+
+## Security
+
+Based on Spring Security 7 (Spring Boot 4 default).
+
+```java
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http
+        .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/api/public/**").permitAll()
+            .requestMatchers("/api/admin/**").hasRole("ADMIN")
+            .anyRequest().authenticated()
+        )
+        .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+        .build();
+  }
+}
+```
+
+**Conventions:**
+- Use Lambda DSL (deprecated method-chaining style is removed)
+- Enable method-level security with `@EnableMethodSecurity`
+- Explicitly configure CORS and CSRF policies
+
+---
+
+## Data Access
+
+### JPA Entity
+```java
+@Entity
+@Table(name = "orders")
+public class Order {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true, length = 20)
+  private String orderNumber;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private OrderStatus status;
+
+  @Column(nullable = false, precision = 12, scale = 2)
+  private BigDecimal totalAmount;
+
+  @Column(nullable = false, updatable = false)
+  private Instant createdAt;
+
+  protected Order() {} // JPA default constructor
+
+  public Order(String orderNumber, BigDecimal totalAmount) {
+    this.orderNumber = orderNumber;
+    this.totalAmount = totalAmount;
+    this.status = OrderStatus.PENDING;
+    this.createdAt = Instant.now();
+  }
+
+  // Expose only getters; replace setters with business methods
+  public void approve() {
+    if (this.status != OrderStatus.PENDING) {
+      throw new IllegalStateException("Can only approve orders in PENDING status");
+    }
+    this.status = OrderStatus.APPROVED;
+  }
+}
+```
+
+**Conventions:**
+- Do NOT use records for entities (JPA requires mutable fields and default constructor)
+- Expose meaningful business methods instead of setters
+- Specify `@Column` constraints explicitly (nullable, length, etc.)
+- Make JPA default constructors `protected`
+- Implement `equals()` / `hashCode()` based on business key or ID
+
+### Repository
+```java
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+  @Nullable
+  Order findByOrderNumber(String orderNumber);
+
+  @Query("""
+      SELECT o FROM Order o
+      WHERE o.status = :status
+        AND o.createdAt >= :since
+      ORDER BY o.createdAt DESC
+      """)
+  Page<Order> findRecentByStatus(
+      @Param("status") OrderStatus status,
+      @Param("since") Instant since,
+      Pageable pageable);
+
+  boolean existsByOrderNumber(String orderNumber);
+}
+```
+
+---
+
+## Observability
+
+Spring Boot 4 ships with Micrometer 1.16 + OpenTelemetry support by default.
+
+```java
+@Service
+public class OrderService {
+
+  private final OrderRepository orderRepository;
+
+  @Observed(name = "order.create", contextualName = "create-order")
+  public OrderResponse createOrder(CreateOrderRequest request) {
+    // Micrometer auto-generates timer, counter, and trace
+    var order = new Order(generateOrderNumber(), calculateTotal(request));
+    orderRepository.save(order);
+    return OrderResponse.from(order);
+  }
+}
+```
+
+```yaml
+# application.yml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
+  observations:
+    annotations:
+      enabled: true
+```
+
+**New OpenTelemetry Starter:**
+```groovy
+implementation("org.springframework.boot:spring-boot-starter-opentelemetry")
+```
+This single starter configures OTLP-based metric and trace export.
+
+---
+
+## Testing
+
+### Unit Tests
+```java
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+  @Mock
+  private OrderRepository orderRepository;
+
+  @Mock
+  private PaymentClient paymentClient;
+
+  @InjectMocks
+  private OrderService orderService;
+
+  @Test
+  @DisplayName("Creates an order for a valid request")
+  void should_createOrder_when_validRequest() {
+    // given
+    var request = new CreateOrderRequest("ITEM-001", 2, null);
+    given(orderRepository.save(any(Order.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    var response = orderService.createOrder(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.status()).isEqualTo("PENDING");
+    then(orderRepository).should().save(any(Order.class));
+  }
+}
+```
+
+### Integration Tests
+```java
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class OrderControllerIntegrationTest {
+
+  @Autowired
+  private TestRestClient restClient;
+
+  @Test
+  @DisplayName("POST /api/orders creates an order")
+  void should_createOrder_via_api() {
+    var request = new CreateOrderRequest("ITEM-001", 2, null);
+
+    var response = restClient.post()
+        .uri("/api/orders")
+        .body(request)
+        .exchange()
+        .expectStatus().isCreated()
+        .expectBody(OrderResponse.class)
+        .returnResult()
+        .getResponseBody();
+
+    assertThat(response).isNotNull();
+    assertThat(response.orderNumber()).isNotBlank();
+  }
+}
+```
+
+**Conventions:**
+- Use `@SpringBootTest` only for integration tests (it is heavyweight)
+- Prefer slice tests: `@WebMvcTest`, `@DataJpaTest`, `@JsonTest`
+- Use `@Testcontainers` for real-database tests
+- Use AssertJ as the default assertion library
+
+---
+
+## Error Handling
+
+### RFC 7807 ProblemDetail
+```java
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(OrderNotFoundException.class)
+  public ProblemDetail handleOrderNotFound(OrderNotFoundException ex) {
+    var problem = ProblemDetail.forStatusAndDetail(
+        HttpStatus.NOT_FOUND, ex.getMessage());
+    problem.setTitle("Order not found");
+    problem.setProperty("orderId", ex.getOrderId());
+    return problem;
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ProblemDetail handleValidation(MethodArgumentNotValidException ex) {
+    var problem = ProblemDetail.forStatusAndDetail(
+        HttpStatus.BAD_REQUEST, "Validation failed");
+    problem.setTitle("Validation Error");
+    var errors = ex.getBindingResult().getFieldErrors().stream()
+        .collect(Collectors.toMap(
+            FieldError::getField,
+            fe -> fe.getDefaultMessage() != null ? fe.getDefaultMessage() : "invalid"
+        ));
+    problem.setProperty("fieldErrors", errors);
+    return problem;
+  }
+}
+```
+
+```yaml
+# Enable ProblemDetail
+spring:
+  mvc:
+    problemdetail:
+      enabled: true
+```
+
+---
+
+## Migration Notes
+
+Key changes when migrating from Spring Boot 3 to 4:
+
+- `javax.*` → `jakarta.*` (should already be done in Boot 3)
+- `spring-jcl` removed → use Apache Commons Logging directly
+- URL pattern matching: suffix pattern and trailing slash matching removed
+- Auto-configuration modules split — import paths may change
+- `@Autowired` on constructors: omitted by default for single constructors
+- Spring Security: Lambda DSL required, deprecated method chaining removed
+- Kotlin: 2.2 baseline


### PR DESCRIPTION
## Summary
- 5개 skill을 각각 독립적인 plugin으로 분리 (1 plugin = 1 skill)
- 모든 SKILL.md에 `user_invocable: true` 추가
- marketplace.json에 5개 plugin 등록, settings.json에 5개 활성화

## Motivation
마켓플레이스에서 5개 스킬이 표시되지 않는 문제 수정.
`go-plugins`(정상 작동) 패턴 분석 결과 2가지 구조적 차이 발견:
1. `user_invocable: true` 누락
2. 1개 plugin에 5개 skill 혼재 (go-plugins는 1:1 매핑)

## Changes
- `java-reviewer`, `java-tester`, `java-25`, `spring` 각각 독립 plugin으로 분리
- 각 plugin에 `.claude-plugin/plugin.json` 생성
- 각 SKILL.md에 `user_invocable: true` 추가
- 각 plugin 내 필요한 reference 파일만 복사 (로컬 상대 경로로 업데이트)
- `marketplace.json`에 5개 plugin 모두 등록
- `settings.json`에 5개 plugin 활성화
- 각 plugin README.md / README.ko.md 생성
- java-coder README를 단독 plugin 설명으로 업데이트

## Test plan
- [ ] `marketplace.json`에 5개 plugin 등록 확인
- [ ] 각 SKILL.md에 `user_invocable: true` 확인
- [ ] 각 plugin에 `.claude-plugin/plugin.json` 확인
- [ ] Claude CLI 마켓플레이스에서 5개 스킬 모두 표시 확인