### PR TITLE
chore: bump java plugin version to 0.0.6 and marketplace to 1.0.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,14 +8,14 @@
   },
   "metadata": {
     "description": "Java plugins marketplace — production-grade Java patterns and best practices",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "plugins": [
     {
       "name": "java",
       "source": "./plugins/java",
       "description": "Java skills — production-grade coding (java:coder), code review (java:reviewer), TDD (java:tester), Spring Boot 4 (java:spring)",
-      "version": "0.0.5"
+      "version": "0.0.6"
     }
   ]
 }

--- a/plugins/java/.claude-plugin/plugin.json
+++ b/plugins/java/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "java",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Java skills — production-grade Java patterns, code review, TDD, Java 25 features, and Spring Boot 4 conventions",
   "author": {
     "name": "ppzxc",

--- a/plugins/java/skills/coder/SKILL.md
+++ b/plugins/java/skills/coder/SKILL.md
@@ -5,7 +5,7 @@ description: >
   NOT for test file writing (java:tester), code review (java:reviewer), or
   Spring Boot patterns (java:spring).
 user-invocable: true
-version: 0.0.5
+version: 0.0.6
 ---
 
 # java:coder

--- a/plugins/java/skills/reviewer/SKILL.md
+++ b/plugins/java/skills/reviewer/SKILL.md
@@ -5,7 +5,7 @@ description: >
   "review this code"), or multi-file quality audits. NOT for generating new code
   or writing tests.
 user-invocable: true
-version: 0.0.5
+version: 0.0.6
 ---
 
 # java:reviewer

--- a/plugins/java/skills/spring/SKILL.md
+++ b/plugins/java/skills/spring/SKILL.md
@@ -5,7 +5,7 @@ description: >
   (@WebMvcTest, @DataJpaTest, @SpringBootTest), ProblemDetail error handling,
   API versioning, or any Spring Framework 7 / Jakarta EE 11 patterns.
 user-invocable: true
-version: 0.0.5
+version: 0.0.6
 ---
 
 # java:spring

--- a/plugins/java/skills/tester/SKILL.md
+++ b/plugins/java/skills/tester/SKILL.md
@@ -4,7 +4,7 @@ description: >
   file creation/modification, explicit TDD workflow requests, test strategy decisions,
   or coverage analysis. NOT for writing production code (java:coder handles that).
 user-invocable: true
-version: 0.0.5
+version: 0.0.6
 ---
 
 # java:tester


### PR DESCRIPTION
## Summary
- Java plugin 버전 0.0.5 → 0.0.6 (plugin.json, 4개 SKILL.md)
- Marketplace 버전 1.0.2 → 1.0.3 (marketplace.json)

## Motivation
정기 버전 범프. 신규 패턴 및 규칙 개선 반영 후 릴리즈 버전 업데이트.

## Changes
- `.claude-plugin/marketplace.json`: metadata.version 1.0.2→1.0.3, plugins[0].version 0.0.5→0.0.6
- `plugins/java/.claude-plugin/plugin.json`: version 0.0.5→0.0.6
- `plugins/java/skills/{coder,reviewer,tester,spring}/SKILL.md`: frontmatter version 0.0.5→0.0.6

## Test plan
- [ ] marketplace.json 버전 확인
- [ ] plugin.json 버전 확인
- [ ] 모든 SKILL.md frontmatter 버전 확인