### PR TITLE
fix(java): resolve all remaining PR#4 review issues (#5,6,8,9,11,12,14,15)

### DIFF
--- a/plugins/java/skills/coder/SKILL.md
+++ b/plugins/java/skills/coder/SKILL.md
@@ -17,6 +17,18 @@ version: 0.0.6
 - API 설계 (Spring Controller 제외 → `java:spring`)
 - 리팩토링 작업
 
+### 경계 예시 — `java:coder` vs `java:spring`
+
+| 작업 | 스킬 |
+|------|------|
+| `record CreateOrderRequest(...)` — 순수 DTO 정의 | `java:coder` |
+| `class OrderNotFoundException extends RuntimeException` — 도메인 예외 | `java:coder` |
+| `interface OrderRepository` — 도메인 Repository 인터페이스 | `java:coder` |
+| `interface OrderService` — 서비스 인터페이스 (Spring 어노테이션 없음) | `java:coder` |
+| `@Service class OrderServiceImpl` — Spring DI/트랜잭션 포함 구현체 | `java:spring` |
+| `@RestController class OrderController` — Spring MVC | `java:spring` |
+| `@Repository class JpaOrderRepository` — Spring Data JPA | `java:spring` |
+
 ## Decision Tree
 
 ### 새 클래스를 만들어야 한다면?

--- a/plugins/java/skills/coder/references/coding-rules.md
+++ b/plugins/java/skills/coder/references/coding-rules.md
@@ -43,7 +43,26 @@ EXCEPTION: 성능상 가변이 필수인 경우
 
 ## Null 처리
 
-RULE: null 반환 금지
+RULE: 계층별 null 표현 전략 — 레이어에 따라 다르게 사용
+WHEN: null 가능성이 있는 값의 타입 결정
+PATTERN:
+- **도메인 레이어** (Entity, VO, Domain Service, Repository Interface): `Optional<T>` 반환. null 반환 전면 금지.
+- **Spring API 레이어** (Controller, @Service public API): `@Nullable`/`@NonNull` 어노테이션 사용 (`org.springframework.lang`).
+  도메인 레이어에서 올라온 `Optional`을 Spring 레이어 경계에서 unwrap하여 `@Nullable` 반환 가능.
+```java
+// 도메인 레이어: Optional
+public interface OrderRepository {
+    Optional<Order> findById(UUID id);
+}
+
+// Spring 레이어: @Nullable (외부 API 계약)
+public @Nullable OrderResponse findOrNull(@NonNull UUID id) {
+    return orderRepository.findById(id).map(OrderResponse::from).orElse(null);
+}
+```
+EXCEPTION: 성능 임계 경로에서 `Optional` 박싱 비용이 문제가 될 때 — `@Nullable` 직접 사용 가능
+
+RULE: null 반환 금지 (도메인 레이어)
 WHEN: 메서드 반환값이 없을 수 있을 때
 PATTERN: `Optional<T>` 반환, 빈 컬렉션 반환(`List.of()`)
 EXCEPTION: 성능 임계 경로에서 `Optional` 박싱 비용이 문제가 될 때

--- a/plugins/java/skills/coder/references/ddd-essentials.md
+++ b/plugins/java/skills/coder/references/ddd-essentials.md
@@ -16,14 +16,17 @@ public class Order {
     @Id
     private final UUID id;
 
+    public UUID getId() { return id; }  // 게터 필수: equals/hashCode에서 프록시 필드 직접 접근 불가
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Order other)) return false;
-        return id != null && id.equals(other.id);  // transient(id=null) 객체는 불일치
+        // other.getId() 사용: Hibernate CGLIB 프록시는 private 필드 미상속 → other.id 는 null
+        return id != null && id.equals(other.getId());
     }
 
     @Override
-    public int hashCode() { return Objects.hashCode(id); }  // JPA 프록시 환경 null-safe
+    public int hashCode() { return Objects.hashCode(id); }  // UUID는 생성 시 할당 → hashCode 안정
 }
 ```
 EXCEPTION: 없음 — 비즈니스 속성으로 equals를 구현하지 않는다

--- a/plugins/java/skills/coder/references/ddd-essentials.md
+++ b/plugins/java/skills/coder/references/ddd-essentials.md
@@ -19,11 +19,11 @@ public class Order {
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Order other)) return false;
-        return id.equals(other.id);
+        return id != null && id.equals(other.id);  // transient(id=null) 객체는 불일치
     }
 
     @Override
-    public int hashCode() { return id.hashCode(); }
+    public int hashCode() { return Objects.hashCode(id); }  // JPA 프록시 환경 null-safe
 }
 ```
 EXCEPTION: 없음 — 비즈니스 속성으로 equals를 구현하지 않는다

--- a/plugins/java/skills/coder/references/jdk25-rules.md
+++ b/plugins/java/skills/coder/references/jdk25-rules.md
@@ -6,8 +6,10 @@
 
 ## Records
 
-RULE: 데이터 운반 객체는 record 사용
-WHEN: DTO, 이벤트 페이로드, 설정값 홀더
+> DTO→record 기본 규칙은 `coding-rules.md` 참조. 여기서는 JDK 16+ record 고급 기능만 다룬다.
+
+RULE: record Compact Constructor로 생성 시 자가 검증
+WHEN: Value Object (VO) 또는 검증이 필요한 record 정의
 PATTERN:
 ```java
 public record Money(BigDecimal amount, Currency currency) {
@@ -19,7 +21,7 @@ public record Money(BigDecimal amount, Currency currency) {
     }
 }
 ```
-EXCEPTION: JPA `@Entity` (프록시 생성 불가), 가변 상태 필요, 상속 필요
+EXCEPTION: 단순 DTO는 컴팩트 생성자 불필요 — Bean Validation 어노테이션으로 대체
 
 RULE: record는 상속 불가 — 공통 동작은 인터페이스로
 PATTERN:

--- a/plugins/java/skills/reviewer/references/review-checklist.md
+++ b/plugins/java/skills/reviewer/references/review-checklist.md
@@ -55,7 +55,7 @@ FIX: 데이터 조작 로직을 도메인 객체 내부 메서드(`order.cancel(
 
 CHECK: DTO가 일반 class로 구현됨 (record 미사용)
 WHY: record가 더 간결하고 불변 보장
-FIX: `record`로 교체
+FIX: `record`로 교체 (→ `coding-rules.md` DTO 규칙 참조)
 
 CHECK: 생성자 매개변수가 4개 이상인데 Builder 미사용
 WHY: 호출자 실수 가능성 높음

--- a/plugins/java/skills/spring/SKILL.md
+++ b/plugins/java/skills/spring/SKILL.md
@@ -18,6 +18,17 @@ version: 0.0.6
 - Spring Data JPA
 - 순수 도메인 Service (비즈니스 로직만, 인프라 의존 없음) → java:coder
 
+### 경계 예시 — `java:spring` vs `java:coder`
+
+| 작업 | 스킬 |
+|------|------|
+| `@Service class OrderServiceImpl` — Spring DI/트랜잭션 포함 | `java:spring` |
+| `@RestController class OrderController` — Spring MVC | `java:spring` |
+| `@Repository class JpaOrderRepository` — Spring Data JPA | `java:spring` |
+| `record CreateOrderRequest(...)` — 순수 DTO 정의 | `java:coder` |
+| `interface OrderRepository` — 도메인 인터페이스 | `java:coder` |
+| `class OrderNotFoundException` — 도메인 예외 | `java:coder` |
+
 ## Decision Tree
 
 ### 어떤 레이어 코드를 작성하는가?

--- a/plugins/java/skills/spring/references/spring-boot4-rules.md
+++ b/plugins/java/skills/spring/references/spring-boot4-rules.md
@@ -366,16 +366,21 @@ public class Order {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    public Long getId() { return id; }  // 게터 필수: 프록시 필드 직접 접근 불가
+
     // Hibernate 프록시 호환: instanceof + Objects.hashCode(id)
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Order other)) return false;
-        return id != null && id.equals(other.id);
+        // other.getId() 사용: CGLIB 프록시는 private 필드 미상속 → other.id 는 null
+        return id != null && id.equals(other.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id);  // id가 null이어도 안전
+        return getClass().hashCode();  // IDENTITY 전략: id가 null→값으로 변경되어 hashCode 불안정
+        // NOTE: 모든 Order 인스턴스가 동일 hashCode → HashSet에서 O(n). equals()는 정확.
+        // UUID 도메인 생성 방식 사용 시 Objects.hashCode(id) 로 변경 가능
     }
 }
 ```

--- a/plugins/java/skills/spring/references/spring-boot4-rules.md
+++ b/plugins/java/skills/spring/references/spring-boot4-rules.md
@@ -112,14 +112,19 @@ public class OrderController {
 }
 ```
 
-RULE: 생성 응답은 `201 Created + Location 헤더`
+RULE: 생성 응답은 `201 Created + Location 헤더` (RFC 7231 준수)
 WHEN: POST로 리소스 생성 시
 PATTERN:
 ```java
 @PostMapping
 public ResponseEntity<OrderResponse> create(@Valid @RequestBody CreateOrderRequest req) {
     OrderResponse order = orderService.create(req);
-    URI location = URI.create("/api/v1/orders/" + order.id());
+    // ServletUriComponentsBuilder: 현재 요청 기반으로 절대 URI 생성 (RFC 7231 준수)
+    // Controller 레이어 전용 — 도메인 레이어에서 직접 참조 금지
+    URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+        .path("/{id}")
+        .buildAndExpand(order.id())
+        .toUri();
     return ResponseEntity.created(location).body(order);
 }
 ```
@@ -227,7 +232,7 @@ public class OrderAlreadyConfirmedException extends RuntimeException { ... }
 
 ## 요청 검증
 
-RULE: DTO에 Bean Validation 어노테이션 적용
+RULE: DTO에 Bean Validation 어노테이션 적용 (DTO 타입은 record — `coding-rules.md` 참조)
 WHEN: Controller 입력 검증
 PATTERN:
 ```java
@@ -346,6 +351,152 @@ Optional<Order> findWithLines(@Param("id") UUID id);
 @EntityGraph(attributePaths = {"lines", "customer"})
 Optional<Order> findDetailById(UUID id);
 ```
+
+---
+
+## JPA Entity 설계
+
+RULE: Entity equals/hashCode — 프록시 안전 패턴
+WHEN: JPA Entity에서 equals/hashCode 오버라이드
+WHY: Hibernate 지연 로딩 프록시는 하위 클래스이므로 `getClass()` 비교 시 불일치 발생
+PATTERN:
+```java
+@Entity
+public class Order {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Hibernate 프록시 호환: instanceof + Objects.hashCode(id)
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Order other)) return false;
+        return id != null && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);  // id가 null이어도 안전
+    }
+}
+```
+EXCEPTION: id가 null인 transient 상태는 `equals` false 반환이 맞다
+
+RULE: Entity 기본 설계 제약
+WHEN: JPA Entity 클래스 설계
+PATTERN:
+- `@NoArgsConstructor(access = AccessLevel.PROTECTED)` 필수 (Hibernate 요구사항)
+- Entity 필드에 `final` 금지 (프록시 생성 불가)
+- 모든 연관관계 기본 `FetchType.LAZY` (필요 시 `@EntityGraph` 활용)
+- Lombok `@Data`, `@Builder`, `@EqualsAndHashCode` 금지 — 수동 구현 필수
+
+RULE: `@GeneratedValue` 기본 전략은 `IDENTITY`
+WHEN: 단일 DB 환경 (MySQL, PostgreSQL)
+PATTERN: `@GeneratedValue(strategy = GenerationType.IDENTITY)`
+EXCEPTION: 분산 환경 / 애플리케이션 레벨 ID 생성 → `UUID` + `GenerationType.UUID` (JPA 3.1+)
+
+RULE: 양방향 관계 동기화 편의 메서드
+WHEN: 양방향 연관관계 설정 시
+PATTERN:
+```java
+@Entity
+public class Order {
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderLine> lines = new ArrayList<>();
+
+    public void addLine(OrderLine line) {
+        lines.add(line);
+        line.setOrder(this);  // 양방향 동기화
+    }
+}
+```
+
+---
+
+## @Transactional 전략
+
+> 기본 규칙은 상단 `핵심 컨벤션` 섹션 참조.
+
+RULE: 클래스 레벨 `@Transactional(readOnly = true)` 기본 적용
+WHEN: Service 클래스 전반
+WHY: 쓰기 방지 + Hibernate dirty checking 비용 절감 + 읽기 전용 DB 라우팅 가능
+PATTERN:
+```java
+@Service
+@Transactional(readOnly = true)
+public class OrderService {
+    public Order findById(UUID id) { ... }  // readOnly 상속
+
+    @Transactional  // 쓰기 메서드만 재정의
+    public Order create(CreateOrderRequest req) { ... }
+}
+```
+
+RULE: `Propagation.REQUIRES_NEW` 사용 기준
+WHEN: 외부 트랜잭션과 독립적으로 커밋/롤백해야 할 때
+PATTERN:
+```java
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public void saveAuditLog(AuditEntry entry) { ... }  // 외부 롤백과 무관하게 기록
+```
+EXCEPTION: 단순 중첩 호출은 기본 `REQUIRED` 사용 — REQUIRES_NEW는 별도 커넥션 사용
+
+RULE: 격리 수준 — `READ_COMMITTED` 기본
+WHEN: 대부분의 OLTP 트랜잭션
+PATTERN: DB 기본값(MySQL InnoDB, PostgreSQL) 유지. 명시적 변경이 필요한 경우만:
+```java
+@Transactional(isolation = Isolation.READ_COMMITTED)
+```
+EXCEPTION: 금융 집계처럼 반복 읽기 일관성이 중요한 경우 `REPEATABLE_READ`
+
+RULE: 트랜잭션 내 이벤트 발행은 `@TransactionalEventListener`
+WHEN: 도메인 이벤트를 트랜잭션 커밋 후 처리해야 할 때
+PATTERN:
+```java
+// 발행 (커밋 전)
+publisher.publishEvent(new OrderPlacedEvent(order.id()));
+
+// 수신 (커밋 후 실행 보장)
+@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+public void onOrderPlaced(OrderPlacedEvent event) {
+    notificationService.sendConfirmation(event.orderId());
+}
+```
+
+---
+
+## 페이징 처리
+
+RULE: 페이징 API는 `Pageable` + `Page<T>` 표준 사용
+WHEN: 목록 조회 API
+PATTERN:
+```java
+// Repository
+Page<Order> findByCustomerId(UUID customerId, Pageable pageable);
+
+// Controller
+@GetMapping
+public Page<OrderResponse> list(
+    @RequestParam UUID customerId,
+    @PageableDefault(size = 20, sort = "createdAt", direction = DESC) Pageable pageable
+) {
+    return orderService.findByCustomer(customerId, pageable).map(OrderResponse::from);
+}
+```
+
+RULE: `Page<T>` vs `Slice<T>` 선택 기준
+WHEN: 페이징 응답 타입 결정
+PATTERN:
+- `Page<T>`: 전체 건수(`totalElements`) 필요 시 (관리자 화면, 데이터 그리드)
+- `Slice<T>`: 전체 건수 불필요 시 (모바일 무한 스크롤, 다음 페이지 존재 여부만 필요)
+  → `Slice`는 COUNT 쿼리를 생략하여 성능 우세
+EXCEPTION: 대용량 데이터에서 `Page`의 COUNT 쿼리가 병목이면 `Slice`로 전환
+
+RULE: Offset 페이징 vs Cursor 페이징
+WHEN: 대규모 데이터 또는 실시간 갱신이 잦은 목록
+PATTERN:
+- Offset(`Pageable`): 건수가 적거나 고정된 데이터, 구현 간단
+- Cursor(Keyset): 수백만 건 이상, 실시간 추가/삭제 빈번, 무한 스크롤
+  → `WHERE id > :lastId ORDER BY id LIMIT :size` 방식
 
 ---
 


### PR DESCRIPTION
## Summary

- **#5** ddd-essentials.md: `Objects.hashCode(id)` for JPA proxy null-safety + `equals` null guard for transient entities
- **#6** spring-boot4-rules.md: `ServletUriComponentsBuilder` for RFC 7231 compliant Location header (Controller layer only)
- **#8** coding-rules.md: Explicit layer-based `Optional` vs `@Nullable` rule — domain layer = `Optional`, Spring API layer = `@Nullable/@NonNull`
- **#9** coder/SKILL.md + spring/SKILL.md: Trigger boundary examples table to disambiguate coder vs spring skill selection
- **#11** jdk25-rules.md + review-checklist.md + spring-boot4-rules.md: `coding-rules.md` is now the SSoT for DTO→record rule; others replaced with cross-references
- **#12** spring-boot4-rules.md: JPA Entity design guide (proxy-safe equals/hashCode, `protected` no-args constructor, no `final` fields, `LAZY` default, `IDENTITY` strategy, bidirectional sync methods)
- **#14** spring-boot4-rules.md: `@Transactional` strategy guide (`readOnly=true` class default, `REQUIRES_NEW` criteria, `READ_COMMITTED` baseline, `@TransactionalEventListener`)
- **#15** spring-boot4-rules.md: `Pageable`/`Page<T>` paging guide (`Page` vs `Slice` selection, `@PageableDefault`, offset vs cursor)

Issues resolved from original PR#4 review (already closed separately):
- **#7** jdk25-rules.md: StableValue Preview marking (resolved in PR#19)
- **#10** Mock strategy SSoT (resolved in PR#19)
- **#13** Lombok guide (resolved in PR#19)

## Test plan
- [ ] `grep -r "DTO는 record" plugins/` → `coding-rules.md`에만 존재
- [ ] `grep -r "데이터 운반 객체는 record" plugins/` → 존재하지 않음 (cross-ref로 교체됨)
- [ ] `grep -r "ServletUriComponentsBuilder" plugins/` → `spring-boot4-rules.md`에만 존재
- [ ] `grep -r "Objects.hashCode" plugins/` → `ddd-essentials.md`, `spring-boot4-rules.md` 존재 확인
- [ ] `spring-boot4-rules.md`에 JPA Entity, @Transactional, Pageable 섹션 존재 확인